### PR TITLE
Introduce Webpack

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,14 +67,12 @@ sharetribe.listings.show({search: {keywords: "apartment"}}).then(function(result
 });
 ```
 
-# Examples [DRAFT]
+# Examples
 
-You can find examples under the `[examples/](./examples)` directory:
+You can find all examples under the `[examples/](./examples)` directory:
 
-- [ ] Authentication
-- [ ] Search listings
-- [ ] Post a new listing
-- [ ] Start a new transaction
+- [Hello World example in Node.js](./examples/hello-world-node)
+- [Hello World example in browser](./examples/hello-world-browser)
 
 # Installation [DRAFT]
 
@@ -87,6 +85,12 @@ npm install sharetribe-sdk
 Full documentation is available at [TODO Add link to Slate](./)
 
 # Development [DRAFT]
+
+To rebuild the package:
+
+```
+$ npm run build
+```
 
 Run all tests:
 

--- a/examples/hello-world-browser/README.md
+++ b/examples/hello-world-browser/README.md
@@ -1,0 +1,3 @@
+# Hello World example in browser
+
+To run the example, open [index.html](./index.html) in the browser.

--- a/examples/hello-world-browser/index.html
+++ b/examples/hello-world-browser/index.html
@@ -1,0 +1,11 @@
+<html>
+  <head>
+    <title>Hello World example!</title>
+  </head>
+  <body>
+    <script src="../../lib/sharetribe-sdk.js"></script>
+    <script>
+      document.write(sharetribeSdk.hello("John"));
+    </script>
+  </body>
+</html>

--- a/examples/hello-world-node/README.md
+++ b/examples/hello-world-node/README.md
@@ -1,0 +1,9 @@
+# Hello World example in Node.js
+
+To run the example:
+
+```
+$ cd [project-root]
+$ cd examples/hello-world-node
+$ node index.js
+```

--- a/examples/hello-world-node/index.js
+++ b/examples/hello-world-node/index.js
@@ -1,0 +1,10 @@
+// To run the example:
+//
+// $ cd [project-root]
+// $ cd examples/hello-world-node
+// $ node index.js
+//
+
+var sharetribe = require('../../lib/sharetribe-sdk');
+
+console.log(sharetribe.hello("John"));

--- a/lib/sharetribe-sdk.js
+++ b/lib/sharetribe-sdk.js
@@ -1,0 +1,91 @@
+(function webpackUniversalModuleDefinition(root, factory) {
+	if(typeof exports === 'object' && typeof module === 'object')
+		module.exports = factory();
+	else if(typeof define === 'function' && define.amd)
+		define([], factory);
+	else if(typeof exports === 'object')
+		exports["sharetribeSdk"] = factory();
+	else
+		root["sharetribeSdk"] = factory();
+})(this, function() {
+return /******/ (function(modules) { // webpackBootstrap
+/******/ 	// The module cache
+/******/ 	var installedModules = {};
+
+/******/ 	// The require function
+/******/ 	function __webpack_require__(moduleId) {
+
+/******/ 		// Check if module is in cache
+/******/ 		if(installedModules[moduleId])
+/******/ 			return installedModules[moduleId].exports;
+
+/******/ 		// Create a new module (and put it into the cache)
+/******/ 		var module = installedModules[moduleId] = {
+/******/ 			i: moduleId,
+/******/ 			l: false,
+/******/ 			exports: {}
+/******/ 		};
+
+/******/ 		// Execute the module function
+/******/ 		modules[moduleId].call(module.exports, module, module.exports, __webpack_require__);
+
+/******/ 		// Flag the module as loaded
+/******/ 		module.l = true;
+
+/******/ 		// Return the exports of the module
+/******/ 		return module.exports;
+/******/ 	}
+
+
+/******/ 	// expose the modules object (__webpack_modules__)
+/******/ 	__webpack_require__.m = modules;
+
+/******/ 	// expose the module cache
+/******/ 	__webpack_require__.c = installedModules;
+
+/******/ 	// identity function for calling harmory imports with the correct context
+/******/ 	__webpack_require__.i = function(value) { return value; };
+
+/******/ 	// define getter function for harmory exports
+/******/ 	__webpack_require__.d = function(exports, name, getter) {
+/******/ 		Object.defineProperty(exports, name, {
+/******/ 			configurable: false,
+/******/ 			enumerable: true,
+/******/ 			get: getter
+/******/ 		});
+/******/ 	};
+
+/******/ 	// getDefaultExport function for compatibility with non-harmony modules
+/******/ 	__webpack_require__.n = function(module) {
+/******/ 		var getter = module && module.__esModule ?
+/******/ 			function getDefault() { return module['default']; } :
+/******/ 			function getModuleExports() { return module; };
+/******/ 		__webpack_require__.d(getter, 'a', getter);
+/******/ 		return getter;
+/******/ 	};
+
+/******/ 	// Object.prototype.hasOwnProperty.call
+/******/ 	__webpack_require__.o = function(object, property) { return Object.prototype.hasOwnProperty.call(object, property); };
+
+/******/ 	// __webpack_public_path__
+/******/ 	__webpack_require__.p = "";
+
+/******/ 	// Load entry module and return exports
+/******/ 	return __webpack_require__(__webpack_require__.s = 0);
+/******/ })
+/************************************************************************/
+/******/ ([
+/* 0 */
+/***/ function(module, exports) {
+
+module.exports = {
+  hello: function hello(name) {
+    return ["Hello, ", name, "!"].join("");
+  }
+};
+
+
+/***/ }
+/******/ ])
+});
+;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "sharetribe-sdk",
+  "version": "0.0.1",
+  "description": "Sharetribe SDK for JavaScript",
+  "main": "lib/sharetribe-sdk.js",
+  "scripts": {
+    "build": "webpack"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/sharetribe/sharetribe-sdk-js.git"
+  },
+  "keywords": [
+    "sharetribe",
+    "api",
+    "sdk"
+  ],
+  "author": "Sharetribe",
+  "license": "Apache-2.0",
+  "bugs": {
+    "url": "https://github.com/sharetribe/sharetribe-sdk-js/issues"
+  },
+  "homepage": "https://github.com/sharetribe/sharetribe-sdk-js",
+  "devDependencies": {
+    "webpack": "2.1.0-beta.25"
+  }
+}

--- a/src/index.js
+++ b/src/index.js
@@ -1,0 +1,5 @@
+module.exports = {
+  hello: function hello(name) {
+    return ["Hello, ", name, "!"].join("");
+  }
+};

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,0 +1,9 @@
+module.exports = {
+  entry: './src/index.js',
+  output: {
+    path: './lib',
+    filename: 'sharetribe-sdk.js',
+    library: 'sharetribeSdk',
+    libraryTarget: 'umd'
+  }
+};


### PR DESCRIPTION
This commit adds initial Webpack build configurations. Things like ES6 support with Babel loader are coming soon, not in this commit.

This commit includes following additions:

- Add package.json file
- Add `npm run build` script
- Add webpack.config.js file, with UMD support.
- Add src/index.js file (exports only one `hello` function)
- Add examples how to use the package in Node.js and in browser

The examples are currently super simple. I wanted to add them in order to test that packaging and using the package from Node.js and browser work. However, I feel that in the future we might want to remove these two particular examples and replace them with other more comprehensive examples.