### PR TITLE
Add Mocha and Chai

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,1 +1,1 @@
-lib/
+build/

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ node_modules
 
 # Build
 build/
+
+# Logs
+npm-debug.log

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ If the header doesn't have **[DRAFT]** tag, it means that the paragraph can be c
 
 # Sharetribe SDK for JavaScript [DRAFT]
 
+[![CircleCI](https://circleci.com/gh/sharetribe/sharetribe-sdk-js.svg?style=svg)](https://circleci.com/gh/sharetribe/sharetribe-sdk-js)
+
 JavaScript implementation of Sharetribe SDK to provide easy access to [Sharetribe Marketplace API](./) (TODO: Add link to the API Slate documentation).
 
 - [ ] [Promise-based](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) asynchronous API

--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,6 @@
+test:
+  pre:
+    - npm run build
+  override:
+    - npm test
+    - npm run lint

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "build/sharetribe-sdk.js",
   "scripts": {
     "build": "webpack",
-    "lint": "eslint ."
+    "lint": "eslint .",
+    "test": "mocha --compilers js:babel-core/register --colors ./test/*.spec.js"
   },
   "repository": {
     "type": "git",
@@ -26,9 +27,11 @@
     "babel-core": "^6.21.0",
     "babel-loader": "^6.2.10",
     "babel-preset-es2015": "^6.18.0",
+    "chai": "^3.5.0",
     "eslint": "^3.13.1",
     "eslint-config-airbnb-base": "^11.0.1",
     "eslint-plugin-import": "^2.2.0",
+    "mocha": "^3.2.0",
     "webpack": "2.1.0-beta.25"
   }
 }

--- a/test/.eslintrc.js
+++ b/test/.eslintrc.js
@@ -1,0 +1,14 @@
+module.exports = {
+  globals: {
+    //
+    // Specify globals needed by Mocha/Chai
+    // Set the value to `false` to prevent the variables
+    // to be overriden.
+    // See: http://eslint.org/docs/user-guide/configuring#specifying-globals
+    //
+    describe: false,
+    before: false,
+    it: false,
+    expect: false,
+  },
+}

--- a/test/hello.spec.js
+++ b/test/hello.spec.js
@@ -1,0 +1,8 @@
+import { expect } from 'chai';
+import sharetribe from '../build/sharetribe-sdk';
+
+describe('hello', () => {
+  it('returns a nice greeting with my name on it', () => {
+    expect(sharetribe('John')).to.be.equal('Hello, John!');
+  });
+});


### PR DESCRIPTION
This commit adds Mocha and Chai testing tools to the project. In addition to that, CircleCI integration is added and of course, the mandatory README bagde showing that the tests are green.