### PR TITLE
Add universal example

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ You can find all examples under the `[examples/](./examples)` directory:
 
 - [Hello World example in Node.js](./examples/hello-world-node)
 - [Hello World example in browser](./examples/hello-world-browser)
+- [Universal example: Use the SDK in browser and server to fetch the current ISS space station location](./examples/iss)
 
 # Installation [DRAFT]
 

--- a/examples/iss/README.md
+++ b/examples/iss/README.md
@@ -1,0 +1,19 @@
+# Universal example - Use the SDK in browser and server to fetch the current ISS space station location
+
+This example demos the universal use of the SDK. The demo fetches the current location of ISS space station and renders it on server (see the source code). In the browser, it uses the SDK to refresh the ISS location every 5 seconds.
+
+## Start the server
+
+Install dependencies:
+
+```
+npm install
+```
+
+Start the server:
+
+```
+node index.js
+```
+
+Open [http://localhost:3344](http://localhost:3344) in your browser.

--- a/examples/iss/bundle.js
+++ b/examples/iss/bundle.js
@@ -1,0 +1,5 @@
+const renderBodyHtml = (issData) => `<p>This example demos the universal use of the SDK. The demo fetches the current location of ISS space station and renders it on server (see the source code). In the browser, it uses the SDK to refresh the ISS location every 5 seconds.</p><p>ISS Location: ${issData.iss_position.latitude} lat, ${issData.iss_position.longitude} lng`;
+
+module.exports = {
+  renderBodyHtml
+};

--- a/examples/iss/index.js
+++ b/examples/iss/index.js
@@ -1,0 +1,60 @@
+const express = require('express');
+const app = express();
+const path = require('path');
+const fs = require('fs');
+
+// Load the "app bundle" for server
+const bundle = require('./bundle');
+
+// Load the "app bundle" as string and render it
+const bundleString = fs.readFileSync('./bundle.js');
+
+// Load SDK for Node
+const sharetribe = require('../../build/sharetribe-sdk-node').default;
+
+// Initialize the SDK instance
+const sdk = sharetribe({
+  baseUrl: 'http://api.open-notify.org/',
+}, [
+  { path: 'iss-now/' },
+]);
+
+// Setup static asset path for browser to fetch the build package
+app.use('/build', express.static(path.join(__dirname, '../../build')));
+
+// Add one root route and do the server rendering
+app.get('/', (req, res) => {
+  sdk['iss-now']().then((iss) => {
+    res.send(
+`
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Server-rendering example</title>
+    <script src="/build/sharetribe-sdk-web.js"></script>
+    <script>
+      const sdk = sharetribeSdk.default({baseUrl: 'http://api.open-notify.org/'}, [{ path: 'iss-now/' }]);
+
+      // Load the bundle
+      const module = {};
+      ((module) => {
+        ${bundleString}
+      })(module);
+      const bundle = module.exports;
+
+      const redraw = (html) => { document.body.innerHTML = html };
+      setInterval(() => { sdk['iss-now']().then((iss) => { redraw(bundle.renderBodyHtml(iss.data))})}, 5000);
+      console.log('Timer started');
+    </script>
+  </head>
+  <body>${bundle.renderBodyHtml(iss.data)}</body>
+</html>
+`
+    );
+  });
+});
+
+app.listen(3344, () => {
+  console.log('Example app listening on port 3344!')
+});
+

--- a/examples/iss/package.json
+++ b/examples/iss/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "iss",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "express": "^4.14.0"
+  }
+}


### PR DESCRIPTION
Add a universal example, which uses the SDK in browser and in server.

The example fetches the current location of ISS space station and renders that on server-side. In browser, the same SDK is used to refresh the location in every 5 seconds.