### PR TITLE
Don't use the default export

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ JavaScript implementation of Sharetribe SDK to provide easy access to [Sharetrib
 // Add config options, if needed.
 var config = {};
 
-var sharetribe = require('sharetribe-sdk')(config);
+var sharetribe = require('sharetribe-sdk').createInstance(config);
 
 sharetribe.marketplace.show({ id: '0e0b60fe-d9a2-11e6-bf26-cec0c932ce01' }).then(function(result) {
   console.log(result);
@@ -56,7 +56,7 @@ sharetribe.marketplace.show({ id: '0e0b60fe-d9a2-11e6-bf26-cec0c932ce01' }).then
 There are a few config options that can given for the initializatio function:
 
 ``` js
-var sharetribe = require('sharetribe-sdk')({
+var sharetribe = require('sharetribe-sdk').createInstance({
 
   // The API base URL
   baseUrl: "https://api.sharetribe.com/v1/",

--- a/examples/hello-world-browser/index.html
+++ b/examples/hello-world-browser/index.html
@@ -7,18 +7,18 @@
     <script src="../../build/sharetribe-sdk-web.js"></script>
     <script>
 
-      var inst = sharetribeSdk.default({
+      var inst = sharetribeSdk.createInstance({
         baseUrl: "https://jsonplaceholder.typicode.com",
         endpoints: [
-          { path: "users/" },
+          { path: "albums/" },
         ],
       });
 
       inst
-        .users()
+        .albums()
         .then(function(res) {
-          document.write(res.data.map(function(user) {
-            return [user.name, user.username, user.email].join(', ')
+          document.write(res.data.map(function(album) {
+            return [album.id, album.userId, album.title].join(', ')
           }).join('<br />'));
         });
     </script>

--- a/examples/hello-world-node/index.js
+++ b/examples/hello-world-node/index.js
@@ -7,16 +7,16 @@
 // $ node index.js
 //
 
-const sharetribe = require('../../build/sharetribe-sdk-node').default;
+const sharetribeSdk = require('../../build/sharetribe-sdk-node');
 
 /* eslint no-console: "off" */
-const inst = sharetribe({
+const inst = sharetribeSdk.createInstance({
   baseUrl: 'https://jsonplaceholder.typicode.com',
   endpoints: [{
-    path: 'users/',
+    path: 'albums/',
   }],
 });
 
 inst
-  .users()
-  .then(res => console.log(res.data.map(user => [user.name, user.username, user.email].join(', ')).join('\n')));
+  .albums()
+  .then(res => console.log(res.data.map(album => [album.id, album.userId, album.title].join(', ')).join('\n')));

--- a/examples/iss/index.js
+++ b/examples/iss/index.js
@@ -14,10 +14,10 @@ const bundle = require('./bundle');
 const bundleString = fs.readFileSync('./bundle.js');
 
 // Load SDK for Node
-const sharetribe = require('../../build/sharetribe-sdk-node').default;
+const sharetribeSdk = require('../../build/sharetribe-sdk-node');
 
 // Initialize the SDK instance
-const sdk = sharetribe({
+const sdk = sharetribeSdk.createInstance({
   baseUrl: 'http://api.open-notify.org/',
   endpoints: [
     { path: 'iss-now/' },
@@ -37,7 +37,7 @@ app.get('/', (req, res) => {
     <title>Server-rendering example</title>
     <script src="/build/sharetribe-sdk-web.js"></script>
     <script>
-      const sdk = sharetribeSdk.default({baseUrl: 'http://api.open-notify.org/', endpoints: [{ path: 'iss-now/' }]});
+      const sdk = sharetribeSdk.createInstance({baseUrl: 'http://api.open-notify.org/', endpoints: [{ path: 'iss-now/' }]});
 
       // Load the bundle
       const module = {};

--- a/repl.js
+++ b/repl.js
@@ -8,7 +8,7 @@ const colors = require('colors');
 const repl = require('repl');
 const sharetribeSdk = require('./src/index');
 
-const sdk = sharetribeSdk.default({
+const sdk = sharetribeSdk.createInstance({
   baseUrl: 'http://localhost:8088/v1/api/',
 });
 

--- a/src/index.js
+++ b/src/index.js
@@ -3,4 +3,7 @@ import SharetribeSdk from './sdk';
 const createInstance = config =>
   new SharetribeSdk(config);
 
-export default createInstance;
+/* eslint-disable import/prefer-default-export */
+export {
+  createInstance,
+};


### PR DESCRIPTION
- Instead of default export, export the createInstance function
- We need to do this because we want to export also the types