### PR TITLE
Implement token refresh logic

### DIFF
--- a/src/fake.js
+++ b/src/fake.js
@@ -15,6 +15,20 @@ const adapterHelper =
 
 const parseFormData = data => _.fromPairs(data.split('&').map(keyValue => keyValue.split('=')));
 
+const revoke = (config, resolve, reject) => {
+  const formData = parseFormData(config.data);
+
+  if (formData.token) {
+    if (formData.token === '74344396-d9af-458a-adbc-7ff1cb2661d0-fcaeb2c8-6089-4dc3-aa47-7c1ef57f9163') {
+      return resolve({ data: 'revoked' });
+    }
+
+    return resolve({ data: '' });
+  }
+
+  return reject({ data: '' });
+};
+
 const auth = (config, resolve, reject) => {
   const formData = parseFormData(config.data);
 
@@ -300,6 +314,8 @@ const createAdapter = () =>
         return requireAuth(config, reject).then(() => listings.search(config, resolve));
       case '/v1/auth/token':
         return auth(config, resolve, reject);
+      case '/v1/auth/revoke':
+        return revoke(config, resolve, reject);
       default:
         throw new Error(`Not implemented to Fake adapter: ${config.url}`);
     }

--- a/src/sdk.test.js
+++ b/src/sdk.test.js
@@ -296,4 +296,30 @@ describe('new SharetribeSdk', () => {
       });
     });
   });
+
+  it.only('revokes token (a.k.a logout)', () => {
+    const tokenStore = memoryStore();
+
+    const sdk = new SharetribeSdk({
+      baseUrl: '',
+      clientId: '08ec69f6-d37e-414d-83eb-324e94afddf0',
+      endpoints: [],
+      adapter: fake(),
+      tokenStore,
+    });
+
+    // First, login
+    return sdk.login({ username: 'joe.dunphy@example.com', password: 'secret-joe' }).then(() => {
+      expect(tokenStore.getToken().access_token).toEqual('dyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJtYXJrZXRwbGFjZS1pZCI6IjE2YzZhNGI4LTg4ZWUtNDI5Yi04MzVhLTY3MjUyMDZjZDA4YyIsImNsaWVudC1pZCI6IjA4ZWM2OWY2LWQzN2UtNDE0ZC04M2ViLTMyNGU5NGFmZGRmMCIsInRlbmFuY3ktaWQiOiIxNmM2YTRiOC04OGVlLTQyOWItODM1YS02NzI1MjA2Y2QwOGMiLCJzY29wZSI6InVzZXIiLCJleHAiOjE0ODY2NTY1NzEsInVzZXItaWQiOiIzYzA3M2ZhZS02MTcyLTRlNzUtOGI5Mi1mNTYwZDU4Y2Q0N2MifQ.XdRyKz6_Nc6QJDGZIZ7URdOz7V3tBCkD9olRTYIBL44');
+
+      // Revoke token
+      return sdk.logout().then(() => {
+        expect(tokenStore.getToken()).toEqual(null);
+
+        return sdk.marketplace.show({ id: '0e0b60fe-d9a2-11e6-bf26-cec0c932ce01' }).then(() => {
+          expect(tokenStore.getToken().access_token).toEqual('eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJtYXJrZXRwbGFjZS1pZCI6IjE2YzZhNGI4LTg4ZWUtNDI5Yi04MzVhLTY3MjUyMDZjZDA4YyIsImNsaWVudC1pZCI6IjA4ZWM2OWY2LWQzN2UtNDE0ZC04M2ViLTMyNGU5NGFmZGRmMCIsInRlbmFuY3ktaWQiOiIxNmM2YTRiOC04OGVlLTQyOWItODM1YS02NzI1MjA2Y2QwOGMiLCJzY29wZSI6InB1YmxpYy1yZWFkIiwiZXhwIjoxNDg2NDcwNDg3fQ.6l_rV-hLbod-lfakhQTNxF7yY-4SEtaVGIPq2pO_2zo');
+        });
+      });
+    });
+  });
 });


### PR DESCRIPTION
This PR adds token refresh logic to the SDK

As listed in the [ADR](https://github.com/sharetribe/sharetribe-custom/blob/master/doc/adrs/006-authentication.md#implementing-support-in-js-sdk):

- [X] If the API Server responds with 401 Unauthorized and a Refresh Token is found in storage then first use Grant type Refresh Token to get a fresh access token and then try the original API call again.
- [X] If the API Server responds with 401 Unauthorized and no Refresh Token is found in storage get a fresh Access Token for anonymous access and then try the original API call again.

TODO

- [X] Implement refresh logic
- [X] Implement logout
- [ ] Code clean up
- [ ] Test clean up

Code clean up is not done in this PR. Check out the refactoring PR #24 