### PR TITLE
Implement authInfo

### DIFF
--- a/src/authenticate.js
+++ b/src/authenticate.js
@@ -173,6 +173,21 @@ export class FetchAuthToken {
   }
 }
 
+export class AuthInfo {
+  enter(ctx) {
+    const { tokenStore } = ctx;
+    const storedToken = tokenStore && tokenStore.getToken();
+
+    if (storedToken) {
+      const grantType = storedToken.refresh_token ? 'refresh_token' : 'client_credentials';
+
+      return { ...ctx, res: { grantType } };
+    }
+
+    return { ...ctx, res: {} };
+  }
+}
+
 export const authenticateInterceptors = [
   new FetchAuthToken(),
   new RetryWithAnonToken(),

--- a/src/context_runner.js
+++ b/src/context_runner.js
@@ -1,10 +1,22 @@
+const DEBUG = false;
+
 const resolve = ctx => Promise.resolve(ctx);
 
 const buildCtx = (params = {}, middleware) =>
   ({ ...params, enterQueue: [...middleware].reverse(), leaveStack: [] });
 
-const tryExecuteMw = (ctx, mw, stage) =>
-  resolve(ctx).then(mw[stage] || resolve).catch((error) => {
+const tryExecuteMw = (ctx, mw, stage) => {
+  /* eslint-disable no-console */
+  /* eslint-disable no-undef */
+  if (DEBUG) {
+    if (mw[stage]) {
+      console.log(`Executing ${mw.constructor.name}#${stage}`);
+    }
+  }
+  /* eslint-enable no-console */
+  /* eslint-enable no-undef */
+
+  return resolve(ctx).then(mw[stage] || resolve).catch((error) => {
     const errorCtx = error.ctx || ctx;
     return Promise.resolve({
       ...errorCtx,
@@ -13,6 +25,7 @@ const tryExecuteMw = (ctx, mw, stage) =>
       errorStage: stage,
     });
   });
+};
 
 const nextMw = (ctx) => {
   const leaveStack = [...ctx.leaveStack];

--- a/src/sdk.js
+++ b/src/sdk.js
@@ -9,7 +9,8 @@ import { authenticateInterceptors,
          FetchAuthToken,
          AddAuthTokenHeader,
          SaveTokenMiddleware,
-         AddAuthTokenResponseToCtx } from './authenticate';
+         AddAuthTokenResponseToCtx,
+         AuthInfo } from './authenticate';
 import { createDefaultTokenStore } from './token_store';
 import contextRunner from './context_runner';
 
@@ -137,6 +138,7 @@ const logoutInterceptors = [
 const additionalSdkFnDefinitions = [
   { path: 'login', endpointInterceptorName: 'auth.token', interceptors: loginInterceptors },
   { path: 'logout', endpointInterceptorName: 'auth.revoke', interceptors: [...logoutInterceptors] },
+  { path: 'authInfo', interceptors: [new AuthInfo()] },
 ];
 
 // const logAndReturn = (data) => {
@@ -226,10 +228,10 @@ const createEndpointInterceptor = ({ method, url, httpOpts }) => {
  */
 const createSdkFn = ({ ctx, endpointInterceptor, interceptors }) =>
   (params = {}) =>
-    contextRunner([
+    contextRunner(_.compact([
       ...interceptors,
       endpointInterceptor,
-    ])({ ...ctx, params }).then(({ res }) => res);
+    ]))({ ...ctx, params }).then(({ res }) => res);
 
 // Take SDK configurations, do transformation and return.
 const transformSdkConfig = ({ baseUrl, tokenStore, ...sdkConfig }) => ({

--- a/src/sdk.test.js
+++ b/src/sdk.test.js
@@ -323,4 +323,36 @@ describe('new SharetribeSdk', () => {
       });
     }));
   });
+
+  describe('authInfo', () => {
+    it('returns authentication information', () => {
+      const tokenStore = memoryStore();
+
+      const sdk = new SharetribeSdk({
+        baseUrl: '',
+        clientId: '08ec69f6-d37e-414d-83eb-324e94afddf0',
+        endpoints: [],
+        adapter: fake(),
+        tokenStore,
+      });
+
+      return report(sdk.authInfo()
+                       .then((authInfo) => {
+                         // No auth info yet.
+                         expect(authInfo.grantType).toBeUndefined();
+                       })
+                       .then(() => sdk.marketplace.show().then(sdk.authInfo).then((authInfo) => {
+                         // Anonymous token
+                         expect(authInfo.grantType).toEqual('client_credentials');
+                       }))
+                       .then(() => sdk.login({ username: 'joe.dunphy@example.com', password: 'secret-joe' }).then(sdk.authInfo).then((authInfo) => {
+                         // Login token
+                         expect(authInfo.grantType).toEqual('refresh_token');
+                       }))
+                       .then(() => sdk.logout().then(sdk.authInfo).then((authInfo) => {
+                         // Logout
+                         expect(authInfo.grantType).toBeUndefined();
+                       })));
+    });
+  });
 });


### PR DESCRIPTION
`authInfo` function reads saved authentication info from the tokenStore. It returns Promise, because the tokenStore implementation might be (in the future) async store. `authInfo` returns an object with one key, `grantType`. Possible `grantType` values are `undefined` (not authorized), `client_credentials` (anon token) or `refresh_token` (logged in user).