### PR TITLE
Add JSON reviever and replacer functions

### DIFF
--- a/src/types.js
+++ b/src/types.js
@@ -42,18 +42,18 @@ export const replacer = (key = null, value) => {
 
   if (type) {
     // eslint-disable-next-line no-underscore-dangle
-    return { ...value, __type: type };
+    return { ...value, _sdkType: type };
   }
 
   return value;
 };
 
 //
-// JSON reviever
+// JSON reviver
 //
-export const reviever = (key = null, value) => {
+export const reviver = (key = null, value) => {
   // eslint-disable-next-line no-underscore-dangle
-  const type = value && value.__type;
+  const type = value && value._sdkType;
 
   switch (type) {
     case 'LatLng':

--- a/src/types.test.js
+++ b/src/types.test.js
@@ -3,7 +3,7 @@ import {
   LatLng,
   LatLngBounds,
   replacer,
-  reviever,
+  reviver,
 } from './types';
 
 describe('JSON parse/stringify', () => {
@@ -19,25 +19,25 @@ describe('JSON parse/stringify', () => {
   const expectedJsonRep = {
     "uuid": {
       "uuid": "27786d1c-f16b-411b-b1fc-176969a91338",
-      "__type": "UUID"
+      "_sdkType": "UUID"
     },
     "latlng": {
       "lat": 12.34,
       "lng": 45.56,
-      "__type": "LatLng"
+      "_sdkType": "LatLng"
     },
     "latlngbounds": {
       "ne": {
         "lat": 12.34,
         "lng": 23.45,
-        "__type": "LatLng"
+        "_sdkType": "LatLng"
       },
       "sw": {
         "lat": 34.56,
         "lng": 45.67,
-        "__type": "LatLng"
+        "_sdkType": "LatLng"
       },
-      "__type": "LatLngBounds"
+      "_sdkType": "LatLngBounds"
     },
   };
   /* eslint-enable quote-props */
@@ -51,7 +51,7 @@ describe('JSON parse/stringify', () => {
   });
 
   it('parses types', () => {
-    const parsed = JSON.parse(JSON.stringify(testData, replacer), reviever);
+    const parsed = JSON.parse(JSON.stringify(testData, replacer), reviver);
 
     expect(parsed).toEqual(testData);
   });


### PR DESCRIPTION
When the data from SDK is stringified to JSON, the type information gets lost. This PR adds `replacer` and `reviever` helpers which help to keep the type information when the the data is serialized / deserialized.

```
const testData = {
  uuid: new UUID('27786d1c-f16b-411b-b1fc-176969a91338'),
  latlng: new LatLng(12.34, 45.56),
  latlngbounds: new LatLngBounds(new LatLng(12.34, 23.45), new LatLng(34.56, 45.67)),
};

const stringified = JSON.stringify(testData, sdk.types.replacer, 2);

console.log(stringified);

// prints => 
// {
//   "uuid": {
//     "uuid": "27786d1c-f16b-411b-b1fc-176969a91338",
//     "__type": "uuid"
//   },
//   "latlng": {
//     "lat": 12.34,
//     "lng": 45.56,
//     "__type": "latlng"
//   },
//   "latlngbounds": {
//     "ne": {
//       "lat": 12.34,
//       "lng": 23.45,
//       "__type": "latlng"
//     },
//     "sw": {
//       "lat": 34.56,
//       "lng": 45.67,
//       "__type": "latlng"
//     },
//     "__type": "latlngbounds"
//   },
// };

expect(JSON.parse(stringified, sdk.types.revierer)).toEqual(testData) // passes
```

The SDK handles only types that are defined by the SDK. This means that for example `Date` values are ignored, and the SDK user needs to add their own handling for Dates.