### PR TITLE
Fix logout bug 2/2

### DIFF
--- a/src/sdk.js
+++ b/src/sdk.js
@@ -4,7 +4,7 @@ import { fnPath as urlPathToFnPath, trimEndSlash, formData } from './utils';
 import * as serializer from './serializer';
 import paramsSerializer from './params_serializer';
 import { FetchRefreshTokenForRevoke,
-         ClearTokenMiddleware,
+         ClearTokenAfterRevokeMiddleware,
          FetchAuthTokenFromStore,
          FetchAuthTokenFromApi,
          RetryWithAnonToken,
@@ -187,9 +187,9 @@ const loginInterceptors = [
 
 const logoutInterceptors = [
   new FetchAuthTokenFromStore(),
+  new ClearTokenAfterRevokeMiddleware(),
   new RetryWithRefreshToken(),
   new AddAuthTokenHeader(),
-  new ClearTokenMiddleware(),
   new FetchRefreshTokenForRevoke(),
 ];
 


### PR DESCRIPTION
This PR is part of the 3 PR series:

- #36 Fix logout bug 1/2
- #37 Implement adapter token store
- #38 Fix logout bug 1/2

This PR is built on top of #37

This PR improves fixes two remaining bugs in the logout functionality:

1. If the user has expired access token we try to fetch fresh token. If fetching fresh token fails because of 401, the logout should return success response (because we are already logged out)
1. If the user has expired access token we try to fetch fresh token. If fetching fresh token fails because of unknown error (e.g. network error), the logout should return unsuccessful response (and keep the user logged in, i.e. not clearing tokens from cookie)

This PR also adds `offlineAfter(numOfRequest)` function to the fake HTTP adapter. It will make the adapter to throw exception for all subsequent requests after `numOfRequest` requests have been made. This way we can simulate network error.