### PR TITLE
Make TransitRequest interceptor idempotent

### DIFF
--- a/src/interceptors/transit_request.js
+++ b/src/interceptors/transit_request.js
@@ -4,7 +4,13 @@ import { createTransitConverters } from '../serializer';
    Transit encode the request
  */
 export default class TransitRequest {
-  enter({ params, headers = {}, typeHandlers, ...ctx }) {
+  enter(ctx) {
+    const { params, headers = {}, typeHandlers, ...restCtx } = ctx;
+
+    if (headers['Content-Type'] === 'application/transit+json') {
+      return ctx;
+    }
+
     const { writer } = createTransitConverters(typeHandlers);
 
     return {
@@ -14,7 +20,7 @@ export default class TransitRequest {
         'Content-Type': 'application/transit+json',
       },
       typeHandlers,
-      ...ctx,
+      ...restCtx,
     };
   }
 }

--- a/src/interceptors/transit_request.test.js
+++ b/src/interceptors/transit_request.test.js
@@ -1,0 +1,54 @@
+import { createTransitConverters } from '../serializer';
+import TransitRequest from './transit_request';
+
+describe('TransitRequest', () => {
+  it('encodes to Transit', () => {
+    const data = {
+      data: {
+        a: 1,
+        b: [2, 3],
+      },
+    };
+
+    const ctx = {
+      params: data,
+    };
+
+    const transitRequest = new TransitRequest();
+
+    const newCtx = transitRequest.enter(ctx);
+    const { writer } = createTransitConverters();
+
+    expect(newCtx).toEqual(expect.objectContaining({
+      headers: expect.objectContaining({
+        'Content-Type': 'application/transit+json',
+      }),
+      params: writer.write(data),
+    }));
+  });
+
+  it('is idempotent', () => {
+    const data = {
+      data: {
+        a: 1,
+        b: [2, 3],
+      },
+    };
+
+    const ctx = {
+      params: data,
+    };
+
+    const transitRequest = new TransitRequest();
+
+    const newCtx = transitRequest.enter(transitRequest.enter(ctx));
+    const { writer } = createTransitConverters();
+
+    expect(newCtx).toEqual(expect.objectContaining({
+      headers: expect.objectContaining({
+        'Content-Type': 'application/transit+json',
+      }),
+      params: writer.write(data),
+    }));
+  });
+});

--- a/src/sdk.js
+++ b/src/sdk.js
@@ -45,8 +45,8 @@ const defaultSdkConfig = {
    how to transform requests and response, etc.
  */
 const apis = {
-  api: ({ baseUrl, version, adapter }) => {
-    return {
+  api: ({ baseUrl, version, adapter }) =>
+    ({
       headers: {
         Accept: 'application/transit+json',
       },
@@ -55,8 +55,7 @@ const apis = {
       transformResponse: v => v,
       adapter,
       paramsSerializer,
-    };
-  },
+    }),
   auth: ({ baseUrl, version, adapter }) => ({
     headers: {
       'Content-Type': 'application/x-www-form-urlencoded',

--- a/src/serializer.js
+++ b/src/serializer.js
@@ -225,7 +225,7 @@ export const writer = (customWriters = []) => {
   });
 };
 
-export const createTransitConverters = (typeHandlers) => {
+export const createTransitConverters = (typeHandlers = []) => {
   const { readers, writers } = typeHandlers.reduce((memo, handler) => {
     const r = {
       type: handler.type,


### PR DESCRIPTION
This PR makes the TransitRequest middleware idempotent by checking the value of `Content-Type` header before encoding. This is important, because if a POST request fails because of the expired access token, we will retry the request with fresh auth token. In that case, we don't want to double encode the params.