### PR TITLE
Update Jest

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,5 +1,9 @@
 module.exports = {
+  plugins: [
+    'jest'
+  ],
   extends: [
+    'plugin:jest/recommended',
     'airbnb-base',
     'prettier',
   ],

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "eslint-config-airbnb-base": "^11.0.1",
     "eslint-config-prettier": "^1.5.0",
     "eslint-plugin-import": "^2.2.0",
+    "eslint-plugin-jest": "^19.0.1",
     "jest": "^19.0.2",
     "prettier": "^0.22.0",
     "repl.history": "^0.1.4",


### PR DESCRIPTION
Update Jest to 19.0.2. In addition, add Jest ESLint plugin to get errors if there are accidentally skipped/focused tests.