### PR TITLE
Fix double-encoding bug

### DIFF
--- a/src/interceptors/add_auth_header.js
+++ b/src/interceptors/add_auth_header.js
@@ -20,13 +20,13 @@ const constructAuthHeader = authToken => {
  */
 export default class AddAuthHeader {
   enter(ctx) {
-    const { authToken } = ctx;
+    const { authToken, headers = {} } = ctx;
 
     if (!authToken) {
       return ctx;
     }
 
     const authHeaders = { Authorization: constructAuthHeader(authToken) };
-    return { ...ctx, headers: authHeaders };
+    return { ...ctx, headers: { ...headers, ...authHeaders } };
   }
 }

--- a/src/interceptors/add_auth_header.test.js
+++ b/src/interceptors/add_auth_header.test.js
@@ -1,0 +1,50 @@
+import AddAuthHeader from './add_auth_header';
+
+describe('AddAuthHeader', () => {
+  it('adds the auth token to the header', () => {
+    const ctx = {
+      authToken: {
+        token_type: 'Bearer',
+        access_token: 'secret-123',
+      },
+    };
+
+    const addAuthHeader = new AddAuthHeader();
+
+    const newCtx = addAuthHeader.enter(ctx);
+
+    expect(newCtx).toEqual(
+      expect.objectContaining({
+        headers: {
+          Authorization: 'Bearer secret-123',
+        },
+      })
+    );
+  });
+
+  it('merges the new header, and does not override existing headers, except the auth header', () => {
+    const ctx = {
+      authToken: {
+        token_type: 'Bearer',
+        access_token: 'secret-123',
+      },
+      headers: {
+        Authorization: 'Bearer old-invalid-token',
+        'Content-Type': 'application/transit+json',
+      },
+    };
+
+    const addAuthHeader = new AddAuthHeader();
+
+    const newCtx = addAuthHeader.enter(ctx);
+
+    expect(newCtx).toEqual(
+      expect.objectContaining({
+        headers: {
+          Authorization: 'Bearer secret-123',
+          'Content-Type': 'application/transit+json',
+        },
+      })
+    );
+  });
+});


### PR DESCRIPTION
This PR fixes a double encoding bug, which happens if we need to retry the request with fresh authentication token.

The reason for the bug was a badly behaving AddAuthHeader interceptor, which wiped the request headers.