### PR TITLE
Decode Lists to JS arrays

### DIFF
--- a/src/serializer.js
+++ b/src/serializer.js
@@ -199,6 +199,9 @@ export const reader = (customReaders = []) => {
       // can coerse arrays to sets, so it's ok to send arrays
       // to the API when set is expected.
       set: rep => rep,
+
+      // Convert list to an array
+      list: rep => rep,
     },
     mapBuilder,
   });

--- a/src/serializer.test.js
+++ b/src/serializer.test.js
@@ -58,6 +58,14 @@ describe('serializer', () => {
     expect(decoded).toEqual(expect.arrayContaining(['a', 'b']));
   });
 
+  it('decodes a list to an array', () => {
+    const testData = transit.list(['a', 'b']);
+
+    const decoded = reader().read(transit.writer().write(testData));
+
+    expect(decoded).toEqual(expect.arrayContaining(['a', 'b']));
+  });
+
   it('handles UUIDs', () => {
     const testData = {
       id: new UUID('69c3d77a-db3f-11e6-bf26-cec0c932ce01'),


### PR DESCRIPTION
- [X] Remove `arrayBuilder`. It's unnecessary, because by default, Transit JS will convert arrays (i.e. vectors) to JavaScript arrays. Custom arrayBuilder is only needed if you want to convert arrays and vectors to something else, like Immutable.js Lists.
- [X] Add read handler for `list` type. Convert lists to JavaScript arrays.