### PR TITLE
Deprecate some `listings/*` endpoints

### DIFF
--- a/src/sdk.js
+++ b/src/sdk.js
@@ -191,6 +191,13 @@ const endpointDefinitions = [
   },
   {
     apiName: 'api',
+    path: 'own_listings/show',
+    internal: false,
+    method: 'get',
+    interceptors: [new TransitResponse()],
+  },
+  {
+    apiName: 'api',
     path: 'listings/query',
     internal: false,
     method: 'get',


### PR DESCRIPTION
Deprecate some `listings/*` endpoints

- Deprecate listings/query_own, use own_listings/query instead
- Deprecate listings/create, use own_listings/create instead
- Deprecate listings/update, use own_listings/update instead
- Deprecate listings/open, use own_listings/open instead
- Deprecate listings/close, use own_listings/close instead
- Deprecate listings/add_image, use own_listings/add_image instead
- Add own_listings/show endpoint