### PR TITLE
Add Transit JSON Verbose support

### DIFF
--- a/src/interceptors/transit_request.js
+++ b/src/interceptors/transit_request.js
@@ -5,13 +5,13 @@ import { createTransitConverters } from '../serializer';
  */
 export default class TransitRequest {
   enter(ctx) {
-    const { params, headers = {}, typeHandlers, ...restCtx } = ctx;
+    const { params, headers = {}, typeHandlers, transitVerbose, ...restCtx } = ctx;
 
     if (headers['Content-Type'] === 'application/transit+json') {
       return ctx;
     }
 
-    const { writer } = createTransitConverters(typeHandlers);
+    const { writer } = createTransitConverters(typeHandlers, { verbose: transitVerbose });
 
     return {
       params: writer.write(params),
@@ -20,6 +20,7 @@ export default class TransitRequest {
         'Content-Type': 'application/transit+json',
       },
       typeHandlers,
+      transitVerbose,
       ...restCtx,
     };
   }

--- a/src/serializer.js
+++ b/src/serializer.js
@@ -223,10 +223,12 @@ const MapHandler = [
   }),
 ];
 
-export const writer = (customWriters = []) => {
+export const writer = (customWriters = [], opts = {}) => {
   const ownHandlers = constructWriteHandlers(customWriters);
+  const { verbose } = opts;
+  const transitType = verbose ? 'json-verbose' : 'json';
 
-  return transit.writer('json', {
+  return transit.writer(transitType, {
     handlers: transit.map([...ownHandlers, ...MapHandler]),
 
     // This is only needed for the REPL
@@ -243,7 +245,7 @@ export const writer = (customWriters = []) => {
   });
 };
 
-export const createTransitConverters = (typeHandlers = []) => {
+export const createTransitConverters = (typeHandlers = [], opts) => {
   const { readers, writers } = typeHandlers.reduce(
     (memo, handler) => {
       const r = {
@@ -266,6 +268,6 @@ export const createTransitConverters = (typeHandlers = []) => {
 
   return {
     reader: reader(readers),
-    writer: writer(writers),
+    writer: writer(writers, opts),
   };
 };

--- a/src/serializer.test.js
+++ b/src/serializer.test.js
@@ -19,6 +19,22 @@ describe('serializer', () => {
     expect(r.read(w.write(testData))).toEqual(testData);
   });
 
+  it('reads and writes transit JSON verbose', () => {
+    const testData = {
+      a: 1,
+      b: 2,
+      c: [3, 4, 5],
+      d: {
+        e: true,
+      },
+    };
+
+    const r = reader();
+    const w = writer([], { verbose: true });
+
+    expect(r.read(w.write(testData))).toEqual(testData);
+  });
+
   it('writes map keys as symbols', () => {
     const testData = {
       a: 1,


### PR DESCRIPTION
Add Transit JSON Verbose support.

Adds new config `transitVerbose: true/false`

If `transitVerbose` is `true`, the SDK requests server to send responses as JSON Verbose by adding the `X-Transit-Verbose` header. The SDK also sends request body as JSON Verbose transit.