### PR TITLE
Ignore null and undefined query parameter values

### DIFF
--- a/src/params_serializer.test.js
+++ b/src/params_serializer.test.js
@@ -43,4 +43,10 @@ describe('params serializer', () => {
       "Don't know how to serialize query parameter 'foo': [object Object]"
     );
   });
+
+  it('ignores null and undefined values', () => {
+    expect(
+      ps({ a: null, b: undefined, c: 'value', d: false, e: 0, f: '', g: [], h: [1, 2, 3] })
+    ).toEqual('c=value&d=false&e=0&f=&g=&h=1,2,3');
+  });
 });


### PR DESCRIPTION
After longish discussion, we decided to silently ignore null and undefined query parameter values. Ignoring the values is probably easiest to the SDK user. In case of optional values, they can put all the values in one map where the map can contain null values, and the SDK is able to ignore them. On the otherhard, in some cases some broken values may be just silently dropped.