### PR TITLE
fix: update axios dep to secure 0.19

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "webpack": "^3.12.0"
   },
   "dependencies": {
-    "axios": "^0.18.0",
+    "axios": "^0.19.0",
     "js-cookie": "^2.1.3",
     "lodash": "^4.17.10",
     "transit-js": "^0.8.861"


### PR DESCRIPTION
The dependency Axios has a high security issue with v0.18 (https://github.com/axios/axios/issues/2183). This PR updates axios to v0.19.