### PR TITLE
Upgrade docpress

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "babel-preset-es2015": "^6.18.0",
     "babel-preset-stage-3": "^6.17.0",
     "colors": "^1.3.1",
-    "docpress": "^0.7.1",
+    "docpress": "^0.7.6",
     "eslint": "^5.3.0",
     "eslint-config-airbnb-base": "^13.0.0",
     "eslint-config-prettier": "^2.9.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2104,7 +2104,7 @@ docpress-core@~0.9.0:
     slugify "^1.3.2"
     ware "1.3.0"
 
-docpress@^0.7.1:
+docpress@^0.7.6:
   version "0.7.6"
   resolved "https://registry.yarnpkg.com/docpress/-/docpress-0.7.6.tgz#74897454d9f4a27999cbd9220c7c8402d99fc4ca"
   dependencies:
@@ -4534,7 +4534,7 @@ merge@^1.2.0:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/merge/-/merge-1.2.1.tgz#38bebf80c3220a8a487b6fcfb3941bb11720c145"
 
-metalsmith-start@rstacruz/metalsmith-start#e88a7cd:
+"metalsmith-start@github:rstacruz/metalsmith-start#e88a7cd":
   version "2.0.1"
   resolved "https://codeload.github.com/rstacruz/metalsmith-start/tar.gz/e88a7cdbb20aac1db176c121b429008073d8e9eb"
   dependencies:


### PR DESCRIPTION
Old version contained deps that had security vulnerabilities.

Tested quickly that building the docs worked.