### PR TITLE
Show warning if client secret is set in browser

### DIFF
--- a/src/sdk.js
+++ b/src/sdk.js
@@ -778,6 +778,22 @@ const validateSdkConfig = sdkConfig => {
     throw new Error('baseUrl must be provided');
   }
 
+  /* global window, console */
+  const isBrowser = typeof window !== 'undefined' && typeof window.document !== 'undefined';
+
+  if (isBrowser && sdkConfig.clientSecret && !sdkConfig.dangerouslyAllowClientSecretInBrowser) {
+    /* eslint-disable no-console */
+    console.warn(
+      'Security warning! You are using client secret in a browser. This may expose the client secret to the public.'
+    );
+    console.warn(
+      'If you know what you are doing and you have secured the websited by other means (e.g. HTTP auth), you should set the SDK configuration `dangerouslyAllowClientSecretInBrowser` to `true` to dismiss this warning.'
+    );
+    console.warn(
+      'In the future SDK versions, we may change this warning to an error causing the site not to work properly, unless `dangerouslyAllowClientSecretInBrowser` is set'
+    );
+  }
+
   return sdkConfig;
 };
 

--- a/src/sdk.js
+++ b/src/sdk.js
@@ -787,7 +787,7 @@ const validateSdkConfig = sdkConfig => {
       'Security warning! You are using client secret in a browser. This may expose the client secret to the public.'
     );
     console.warn(
-      'If you know what you are doing and you have secured the websited by other means (e.g. HTTP auth), you should set the SDK configuration `dangerouslyAllowClientSecretInBrowser` to `true` to dismiss this warning.'
+      'If you know what you are doing and you have secured the website by other means (e.g. HTTP basic auth), you should set the SDK configuration `dangerouslyAllowClientSecretInBrowser` to `true` to dismiss this warning.'
     );
     console.warn(
       'In the future SDK versions, we may change this warning to an error causing the site not to work properly, unless `dangerouslyAllowClientSecretInBrowser` is set'

--- a/src/sdk.js
+++ b/src/sdk.js
@@ -792,6 +792,7 @@ const validateSdkConfig = sdkConfig => {
     console.warn(
       'In the future SDK versions, we may change this warning to an error causing the site not to work properly, unless `dangerouslyAllowClientSecretInBrowser` is set'
     );
+    /* eslint-enable no-console */
   }
 
   return sdkConfig;


### PR DESCRIPTION
Problem: Every now and then we see that someone is using clientSecret in a browser. This is insecure, since it may leak the clientSecret in case the website is open to the public.

Solution: Shows a warning if clientSecret is set in a browser. Adds a configuration option `dangerouslyAllowClientSecretInBrowser` which will dismiss the warning. A use case for dismissing the warning might be e.g. local development or if the website is secured by other means e.g. HTTP auth.