### PR TITLE
Extend cookie expiration to 180 days

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,9 @@ adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
-- Extend cookie expiration from 30 days to 180 days [#138](https://github.com/sharetribe/flex-sdk-js/pull/138)
+- Extend cookie expiration from 30 days to 180 days. This matches 
+  with the lifetime of the refresh token returned by the Auth API.
+  [#138](https://github.com/sharetribe/flex-sdk-js/pull/138)
 - SDK shows a warning if Client Secret is used in a browser.
   [#134](https://github.com/sharetribe/flex-sdk-js/pull/134)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
+- Extend cookie expiration from 30 days to 180 days [#138](https://github.com/sharetribe/flex-sdk-js/pull/138)
 - SDK shows a warning if Client Secret is used in a browser.
   [#134](https://github.com/sharetribe/flex-sdk-js/pull/134)
 

--- a/src/express_cookie_store.js
+++ b/src/express_cookie_store.js
@@ -1,7 +1,7 @@
 const generateKey = (clientId, namespace) => `${namespace}-${clientId}-token`;
 
 const createStore = ({ clientId, req, res, secure }) => {
-  const expiration = 30; // 30 days
+  const expiration = 180; // 180 days
   const namespace = 'st';
   const key = generateKey(clientId, namespace);
 


### PR DESCRIPTION
To keep refresh token validity and cookie expiration in sync