### PR TITLE
Parse Transit only for application/json content-type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 ### Changed
 
 - Request Assets in JSON format instead of Transit [#160](https://github.com/sharetribe/flex-sdk-js/pull/160)
+- Read response data as Transit only if Content-Type header is `application/transit+json` [#161](https://github.com/sharetribe/flex-sdk-js/pull/161)
 
 
 ## [v1.16.0] - 2022-03-23

--- a/src/fake/adapter.js
+++ b/src/fake/adapter.js
@@ -79,6 +79,12 @@ const marketplaceApiHandler = (config, resolve, reject, tokenStore) => {
       return requireAuth(config, reject, tokenStore).then(() =>
         api.ownListings.create(config, resolve, reject)
       );
+
+    // This returns an error for listing ID "eeeeeeee-eeee-eeee-eeee-000000000500"
+    case 'api/listings/show':
+      return requireAuth(config, reject, tokenStore).then(() =>
+        api.listings.show(config, resolve, reject)
+      );
     default:
       throw new Error(
         `No fake adapter handler implemented for Marketplace API endpoint: ${config.url}`

--- a/src/fake/api.js
+++ b/src/fake/api.js
@@ -15,7 +15,10 @@ export const marketplace = {
                      "~:meta", ["^ "],
                      "~:included", []]`;
 
-    return resolve({ data: res });
+    return resolve({
+      data: res,
+      headers: { 'content-type': 'application/transit+json;charset=UTF-8' },
+    });
   },
 };
 
@@ -32,7 +35,10 @@ export const users = {
                    "~:meta", ["^ "],
                    "~:included", []]`;
 
-    return resolve({ data: res });
+    return resolve({
+      data: res,
+      headers: { 'content-type': 'application/transit+json;charset=UTF-8' },
+    });
   },
 };
 
@@ -79,7 +85,10 @@ export const listings = {
                    "~:meta", ["^ "],
                    "~:included", []]`;
 
-    return resolve({ data: res });
+    return resolve({
+      data: res,
+      headers: { 'content-type': 'application/transit+json;charset=UTF-8' },
+    });
   },
 
   show: (config, resolve, reject) => {
@@ -88,6 +97,7 @@ export const listings = {
         status: 500,
         statusText: 'Internal server error',
         data: 'Internal server error',
+        headers: { 'content-type': 'text/plain' },
       });
     }
 
@@ -107,6 +117,7 @@ export const ownListings = {
       return reject({
         status: 400,
         statusText: 'Bad Request',
+        headers: { 'content-type': 'application/transit+json;charset=UTF-8' },
         data: `["^ ",
           "~:errors", [
             ["^ ",
@@ -144,6 +155,9 @@ export const ownListings = {
           "~:type", "~:ownListing"]]`;
     }
 
-    return resolve({ data: res });
+    return resolve({
+      data: res,
+      headers: { 'content-type': 'application/transit+json;charset=UTF-8' },
+    });
   },
 };

--- a/src/fake/api.js
+++ b/src/fake/api.js
@@ -81,6 +81,18 @@ export const listings = {
 
     return resolve({ data: res });
   },
+
+  show: (config, resolve, reject) => {
+    if (config.params.id === 'eeeeeeee-eeee-eeee-eeee-000000000500') {
+      return reject({
+        status: 500,
+        statusText: 'Internal server error',
+        data: 'Internal server error',
+      });
+    }
+
+    throw new Error('Not implemented');
+  },
 };
 
 export const ownListings = {

--- a/src/interceptors/format_http_response.js
+++ b/src/interceptors/format_http_response.js
@@ -1,14 +1,13 @@
 import _ from 'lodash';
 
 /**
-   Add given params to the `ctx.params`
-
-   Changes to `ctx`:
-
-   - Modify `ctx.params`
+ * Takes `ctx` with HTTP `res` in it and strips internals (e.g. headers, config) and
+ * returns only those values that we want the SDK function to return.
+ *
+ * Should be only used with SDK functions that do HTTP request (e.g. not with AuthInfo)
  */
 
-export default class StripInternalsFromResponse {
+export default class FormatHttpResponse {
   error(ctx) {
     if (!ctx.error.response) {
       return ctx;

--- a/src/interceptors/strip_internals_from_response.js
+++ b/src/interceptors/strip_internals_from_response.js
@@ -1,0 +1,39 @@
+import _ from 'lodash';
+
+/**
+   Add given params to the `ctx.params`
+
+   Changes to `ctx`:
+
+   - Modify `ctx.params`
+ */
+
+export default class StripInternalsFromResponse {
+  error(ctx) {
+    if (!ctx.error.response) {
+      return ctx;
+    }
+
+    return _.update({ ...ctx }, 'error.response', ({ status, statusText, data }) => ({
+      status,
+      statusText,
+      data,
+    }));
+  }
+
+  leave(ctx) {
+    if (!ctx.res) {
+      // Some cases, SDK tries to be smart and not call API endpoint if it's not
+      // needed. For example, `logout` does not call token revoke endpoint if
+      // the user is not logged in.
+      // In those cases, there's no `res` in `ctx`
+      return ctx;
+    }
+
+    return _.update({ ...ctx }, 'res', ({ status, statusText, data }) => ({
+      status,
+      statusText,
+      data,
+    }));
+  }
+}

--- a/src/interceptors/transit_response.js
+++ b/src/interceptors/transit_response.js
@@ -1,6 +1,13 @@
 import _ from 'lodash';
 import { createTransitConverters } from '../serializer';
 
+const isTransit = res => {
+  const headers = res.headers || {};
+  const contentType = headers['content-type'] || '';
+
+  return contentType.startsWith('application/transit+json');
+};
+
 /**
    Transit encode the response
  */
@@ -12,8 +19,7 @@ export default class TransitResponse {
       return ctx;
     }
 
-    // Don't try to parse 500
-    if (ctx.error.response.status === 500) {
+    if (!isTransit(ctx.error.response)) {
       return ctx;
     }
 
@@ -24,6 +30,10 @@ export default class TransitResponse {
     const { reader } = createTransitConverters(ctx.typeHandlers);
 
     if (!ctx.res) {
+      return ctx;
+    }
+
+    if (!isTransit(ctx.res)) {
       return ctx;
     }
 

--- a/src/interceptors/transit_response.js
+++ b/src/interceptors/transit_response.js
@@ -12,6 +12,11 @@ export default class TransitResponse {
       return ctx;
     }
 
+    // Don't try to parse 500
+    if (ctx.error.response.status === 500) {
+      return ctx;
+    }
+
     return _.update({ ...ctx }, 'error.response.data', data => reader.read(data));
   }
 

--- a/src/sdk.js
+++ b/src/sdk.js
@@ -29,7 +29,7 @@ import AuthInfo from './interceptors/auth_info';
 import MultipartRequest from './interceptors/multipart_request';
 import TransitRequest from './interceptors/transit_request';
 import TransitResponse from './interceptors/transit_response';
-import StripInternalsFromResponse from './interceptors/strip_internals_from_response';
+import FormatHttpResponse from './interceptors/format_http_response';
 import { createDefaultTokenStore } from './token_store';
 import contextRunner from './context_runner';
 
@@ -248,7 +248,7 @@ const marketplaceApiSdkFns = (marketplaceApiEndpointInterceptors, ctx) =>
       method,
       ctx,
       interceptors: [
-        new StripInternalsFromResponse(),
+        new FormatHttpResponse(),
         ...authenticateInterceptors,
         ...(_.get(marketplaceApiEndpointInterceptors, fnPath) || []),
       ],
@@ -272,7 +272,7 @@ const authApiSdkFns = (authApiEndpointInterceptors, ctx) => [
     fn: createAuthApiSdkFn({
       ctx,
       interceptors: [
-        new StripInternalsFromResponse(),
+        new FormatHttpResponse(),
         ...loginInterceptors,
         ..._.get(authApiEndpointInterceptors, 'token'),
       ],
@@ -283,7 +283,7 @@ const authApiSdkFns = (authApiEndpointInterceptors, ctx) => [
     fn: createAuthApiSdkFn({
       ctx,
       interceptors: [
-        new StripInternalsFromResponse(),
+        new FormatHttpResponse(),
         ...logoutInterceptors,
         ..._.get(authApiEndpointInterceptors, 'revoke'),
       ],
@@ -334,10 +334,7 @@ const assetsApiSdkFns = (assetsEndpointInterceptors, ctx) => [
           alias: alias || 'latest',
           assetPath: path,
         },
-        interceptors: [
-          new StripInternalsFromResponse(),
-          ..._.get(assetsEndpointInterceptors, 'byAlias'),
-        ],
+        interceptors: [new FormatHttpResponse(), ..._.get(assetsEndpointInterceptors, 'byAlias')],
       });
     },
   },
@@ -360,10 +357,7 @@ const assetsApiSdkFns = (assetsEndpointInterceptors, ctx) => [
           version,
           assetPath: path,
         },
-        interceptors: [
-          new StripInternalsFromResponse(),
-          ..._.get(assetsEndpointInterceptors, 'byVersion'),
-        ],
+        interceptors: [new FormatHttpResponse(), ..._.get(assetsEndpointInterceptors, 'byVersion')],
       });
     },
   },

--- a/src/sdk.js
+++ b/src/sdk.js
@@ -29,6 +29,7 @@ import AuthInfo from './interceptors/auth_info';
 import MultipartRequest from './interceptors/multipart_request';
 import TransitRequest from './interceptors/transit_request';
 import TransitResponse from './interceptors/transit_response';
+import StripInternalsFromResponse from './interceptors/strip_internals_from_response';
 import { createDefaultTokenStore } from './token_store';
 import contextRunner from './context_runner';
 
@@ -156,8 +157,7 @@ const authWithIdpInterceptors = [
 const formatError = e => {
   /* eslint-disable no-param-reassign */
   if (e.response) {
-    const { status, statusText, data } = e.response;
-    Object.assign(e, { status, statusText, data });
+    Object.assign(e, e.response);
     delete e.response;
   }
 
@@ -248,6 +248,7 @@ const marketplaceApiSdkFns = (marketplaceApiEndpointInterceptors, ctx) =>
       method,
       ctx,
       interceptors: [
+        new StripInternalsFromResponse(),
         ...authenticateInterceptors,
         ...(_.get(marketplaceApiEndpointInterceptors, fnPath) || []),
       ],
@@ -270,14 +271,22 @@ const authApiSdkFns = (authApiEndpointInterceptors, ctx) => [
     path: 'login',
     fn: createAuthApiSdkFn({
       ctx,
-      interceptors: [...loginInterceptors, ..._.get(authApiEndpointInterceptors, 'token')],
+      interceptors: [
+        new StripInternalsFromResponse(),
+        ...loginInterceptors,
+        ..._.get(authApiEndpointInterceptors, 'token'),
+      ],
     }),
   },
   {
     path: 'logout',
     fn: createAuthApiSdkFn({
       ctx,
-      interceptors: [...logoutInterceptors, ..._.get(authApiEndpointInterceptors, 'revoke')],
+      interceptors: [
+        new StripInternalsFromResponse(),
+        ...logoutInterceptors,
+        ..._.get(authApiEndpointInterceptors, 'revoke'),
+      ],
     }),
   },
   {
@@ -325,7 +334,10 @@ const assetsApiSdkFns = (assetsEndpointInterceptors, ctx) => [
           alias: alias || 'latest',
           assetPath: path,
         },
-        interceptors: _.get(assetsEndpointInterceptors, 'byAlias'),
+        interceptors: [
+          new StripInternalsFromResponse(),
+          ..._.get(assetsEndpointInterceptors, 'byAlias'),
+        ],
       });
     },
   },
@@ -348,7 +360,10 @@ const assetsApiSdkFns = (assetsEndpointInterceptors, ctx) => [
           version,
           assetPath: path,
         },
-        interceptors: _.get(assetsEndpointInterceptors, 'byVersion'),
+        interceptors: [
+          new StripInternalsFromResponse(),
+          ..._.get(assetsEndpointInterceptors, 'byVersion'),
+        ],
       });
     },
   },
@@ -358,12 +373,6 @@ const assetsApiSdkFns = (assetsEndpointInterceptors, ctx) => [
 //   console.log(data);
 //   return data;
 // };
-
-const handleSuccessResponse = response => {
-  const { status, statusText, data } = response;
-
-  return { status, statusText, data };
-};
 
 // GET requests: `params` includes query params. `queryParams` will be ignored
 // POST requests: `params` includes body params. `queryParams` includes URL query params
@@ -388,7 +397,7 @@ const doRequest = ({ params = {}, queryParams = {}, httpOpts }) => {
     params: query,
   };
 
-  return axios.request(req).then(handleSuccessResponse);
+  return axios.request(req);
 };
 
 /**

--- a/src/sdk.test.js
+++ b/src/sdk.test.js
@@ -123,6 +123,18 @@ describe('new SharetribeSdk', () => {
     });
   });
 
+  it('strips internals from the returned response object', () => {
+    const { sdk } = createSdk();
+
+    return report(
+      sdk.users.show({ id: '0e0b60fe-d9a2-11e6-bf26-cec0c932ce01' }).then(res => {
+        // Allow the following keys. Strip of some 'internals', i.e. config, headers, etc.
+        const expectedKeys = ['status', 'statusText', 'data'];
+        expect(expectedKeys).toEqual(expect.arrayContaining(Object.keys(res)));
+      })
+    );
+  });
+
   it('calls users endpoint with query params', () => {
     const { sdk } = createSdk();
 

--- a/src/sdk.test.js
+++ b/src/sdk.test.js
@@ -5,6 +5,8 @@ import createAdapter from './fake/adapter';
 import SharetribeSdk from './sdk';
 import memoryStore from './memory_store';
 
+const errorListingId = 'eeeeeeee-eeee-eeee-eeee-000000000500';
+
 /**
    Helper to improve error messages.
 
@@ -132,6 +134,34 @@ describe('new SharetribeSdk', () => {
         const expectedKeys = ['status', 'statusText', 'data'];
         expect(expectedKeys).toEqual(expect.arrayContaining(Object.keys(res)));
       })
+    );
+  });
+
+  it('strips internals from the returned error response object', () => {
+    const { sdk } = createSdk();
+
+    return report(
+      sdk.listings
+        .show({ id: errorListingId })
+        .then(() => {
+          // Fail
+          expect(true).toEqual(false);
+        })
+        .catch(e => {
+          expect(e).toBeInstanceOf(Error);
+          expect(e).toEqual(
+            expect.objectContaining({
+              status: 500,
+              statusText: 'Internal server error',
+              data: 'Internal server error',
+            })
+          );
+
+          const expectedKeys = ['status', 'statusText', 'data'];
+          expect(expectedKeys).toEqual(expect.arrayContaining(Object.keys(e)));
+
+          return Promise.resolve();
+        })
     );
   });
 
@@ -870,7 +900,7 @@ describe('new SharetribeSdk', () => {
 
     return report(
       sdk.listings
-        .show({ id: 'eeeeeeee-eeee-eeee-eeee-000000000500' })
+        .show({ id: errorListingId })
         .then(() => {
           // Fail
           expect(true).toEqual(false);

--- a/src/sdk.test.js
+++ b/src/sdk.test.js
@@ -853,6 +853,30 @@ describe('new SharetribeSdk', () => {
     );
   });
 
+  it('returns 500 error data as plain text', () => {
+    const { sdk } = createSdk();
+
+    return report(
+      sdk.listings
+        .show({ id: 'eeeeeeee-eeee-eeee-eeee-000000000500' })
+        .then(() => {
+          // Fail
+          expect(true).toEqual(false);
+        })
+        .catch(e => {
+          expect(e).toBeInstanceOf(Error);
+          expect(e).toEqual(
+            expect.objectContaining({
+              status: 500,
+              statusText: 'Internal server error',
+              data: 'Internal server error',
+            })
+          );
+          return Promise.resolve();
+        })
+    );
+  });
+
   it('returns error in expected error format, data as an object', () => {
     const { sdk } = createSdk();
 


### PR DESCRIPTION
Problem: 500 response is plain text, thus can't be parsed by Transit. This causes Transit to throw a parsing error and thus potentially masking the internal server error.

Solution: Change Transit response interceptor to parse only responses with `application/transit+json` Content-Type header.

What has changed in this PR:

- Transit response interceptors reads the Content-Type header and decides if it should parse or not
- `handleSuccessResponse` function has been removed. This function used to strip out headers from the response right after Axios made the HTTP call. However, Transit response interceptor now needs to read the headers, thus we can't strip them out at this point.
- Add new interceptor `FormatHttpResponse` that strips out headers and other internals from the response right before returning the value to the user. This interceptor works for success (leave) and error (error) paths, thus doing part of the work that the `formatError` function used to do.
- All SDK functions that do API calls now use the `FormatHttpResponse`. `authInfo` doesn't use this interceptor because it doesn't call any API endpoints (only reads from token store)
- Tests are now updated to return Content-Type header.

TODO:

- [x] Changelog update
- [ ] Do the same for Integration SDK