### PR TITLE
JWT as secret

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ jobs:
       ignore:
         - gh-pages
     docker:
-      - image: node:8.10.0
+      - image: node:16.19.1
     steps:
       - checkout
       - run:

--- a/package.json
+++ b/package.json
@@ -60,7 +60,8 @@
     "axios": "^0.21.1",
     "js-cookie": "^2.1.3",
     "lodash": "^4.17.10",
-    "transit-js": "^0.8.861"
+    "transit-js": "^0.8.861",
+    "jsonwebtoken": "^9.0.0"
   },
   "resolutions": {
     "docpress/**/lodash": "^4.17.10"

--- a/src/fake/auth.js
+++ b/src/fake/auth.js
@@ -65,8 +65,8 @@ export const multitenantAuthData = (config, resolve, reject, fakeTokenStore) => 
   let error = {
     status: 401,
     statusText: 'Unauthorized',
-    data: 'Unauthorized'
-  }
+    data: 'Unauthorized',
+  };
 
   if (formData.client_secret === 'valid-secret-valid-hostname') {
     if (formData.grant_type === 'multitenant_client_credentials') {
@@ -75,10 +75,10 @@ export const multitenantAuthData = (config, resolve, reject, fakeTokenStore) => 
         client_data: {
           client_id: '08ec69f6-d37e-414d-83eb-324e94afddf0',
           // for testing purposes, we want to check which endpoint is called
-          called_url: config.url
-        }
+          called_url: config.url,
+        },
       };
-    } 
+    }
   } else if (formData.client_secret === 'valid-secret-invalid-hostname') {
     error = {
       ...error,
@@ -86,7 +86,7 @@ export const multitenantAuthData = (config, resolve, reject, fakeTokenStore) => 
       statusText: 'Not Found',
       data: 'Not Found',
       headers: { 'content-type': 'text/plain' },
-    }
+    };
   }
 
   if (success) {
@@ -103,22 +103,22 @@ export const multitenantClientData = (config, resolve, reject) => {
   let error = {
     status: 401,
     statusText: 'Unauthorized',
-    data: 'Unauthorized'
-  }
+    data: 'Unauthorized',
+  };
 
   if (clientSecret === 'valid-secret-valid-hostname') {
     success = {
       client_id: '08ec69f6-d37e-414d-83eb-324e94afddf0',
       // for testing purposes, we want to check which endpoint is called
-      called_url: config.url
+      called_url: config.url,
     };
   } else if (clientSecret === 'valid-secret-invalid-hostname') {
     error = {
       ...error,
       status: 404,
       statusText: 'Not Found',
-      data: 'Not Found'
-    }
+      data: 'Not Found',
+    };
   }
 
   if (success) {

--- a/src/fake/auth.js
+++ b/src/fake/auth.js
@@ -1,7 +1,16 @@
 import _ from 'lodash';
+import jwt from 'jsonwebtoken';
 
 const parseFormData = data =>
   _.fromPairs(data.split('&').map(keyValue => keyValue.split('=').map(decodeURIComponent)));
+
+const hostnameFromToken = (token, secret) => {
+  try {
+    return jwt.verify(token, secret).hostname;
+  } catch (e) {
+    return null;
+  }
+};
 
 export const revoke = (config, resolve, reject, tokenStore) => {
   const formData = parseFormData(config.data);
@@ -68,7 +77,9 @@ export const multitenantAuthData = (config, resolve, reject, fakeTokenStore) => 
     data: 'Unauthorized',
   };
 
-  if (formData.client_secret === 'valid-secret-valid-hostname') {
+  const hostname = hostnameFromToken(formData.client_secret, 'valid-secret');
+
+  if (hostname === 'valid.example.com') {
     if (formData.grant_type === 'multitenant_client_credentials') {
       success = {
         ...fakeTokenStore.createAnonToken(),
@@ -79,7 +90,7 @@ export const multitenantAuthData = (config, resolve, reject, fakeTokenStore) => 
         },
       };
     }
-  } else if (formData.client_secret === 'valid-secret-invalid-hostname') {
+  } else if (hostname === 'invalid.example.com') {
     error = {
       ...error,
       status: 404,
@@ -97,8 +108,8 @@ export const multitenantAuthData = (config, resolve, reject, fakeTokenStore) => 
 };
 
 export const multitenantClientData = (config, resolve, reject) => {
-  const authHeader = _.get(config.headers, 'Authorization', 'Bearer invalid-secret');
-  const clientSecret = authHeader.replace('Bearer ', '');
+  const authHeader = _.get(config.headers, 'Authorization', 'Bearer invalid-token');
+  const secretToken = authHeader.replace('Bearer ', '');
   let success;
   let error = {
     status: 401,
@@ -106,13 +117,15 @@ export const multitenantClientData = (config, resolve, reject) => {
     data: 'Unauthorized',
   };
 
-  if (clientSecret === 'valid-secret-valid-hostname') {
+  const hostname = hostnameFromToken(secretToken, 'valid-secret');
+
+  if (hostname === 'valid.example.com') {
     success = {
       client_id: '08ec69f6-d37e-414d-83eb-324e94afddf0',
       // for testing purposes, we want to check which endpoint is called
       called_url: config.url,
     };
-  } else if (clientSecret === 'valid-secret-invalid-hostname') {
+  } else if (hostname === 'invalid.example.com') {
     error = {
       ...error,
       status: 404,

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,5 @@
 import SharetribeSdk from './sdk';
+import MultitenantSharetribeSdk from './multitenant_sdk';
 import * as types from './types';
 import browserCookieStore from './browser_cookie_store';
 import expressCookieStore from './express_cookie_store';
@@ -7,6 +8,7 @@ import { read, write } from './serializer';
 import { objectQueryString } from './utils';
 
 const createInstance = config => new SharetribeSdk(config);
+const createMultitenantInstance = config => new MultitenantSharetribeSdk(config);
 
 // Export token stores
 const tokenStore = {
@@ -22,4 +24,4 @@ const transit = { read, write };
 const util = { objectQueryString };
 
 /* eslint-disable import/prefer-default-export */
-export { createInstance, types, tokenStore, transit, util };
+export { createInstance, createMultitenantInstance, types, tokenStore, transit, util };

--- a/src/interceptors/add_multitenant_auth_header.js
+++ b/src/interceptors/add_multitenant_auth_header.js
@@ -1,5 +1,6 @@
 /**
-   Read `clientSecret` from `ctx`. Then construct Authorization header and add it to `headers`.
+   Read `multitenantClientSecretToken` from `ctx` and add it to Authorization
+   header.
 
    Changes to `ctx`:
 
@@ -7,13 +8,8 @@
  */
 export default class AddMultitenantAuthHeader {
   enter(ctx) {
-    const { clientSecret, headers = {} } = ctx;
-
-    if (!clientSecret) {
-      throw new Error('clientSecret is missing from the context');
-    }
-
-    const authHeaders = { Authorization: `Bearer ${clientSecret}` };
+    const { multitenantClientSecretToken, headers = {} } = ctx;
+    const authHeaders = { Authorization: `Bearer ${multitenantClientSecretToken}` };
     return { ...ctx, headers: { ...headers, ...authHeaders } };
   }
 }

--- a/src/interceptors/add_multitenant_auth_token_response.js
+++ b/src/interceptors/add_multitenant_auth_token_response.js
@@ -10,24 +10,19 @@ export default class AddMultitenantAuthTokenResponse {
   /* eslint camelcase: "off" */
   leave(ctx) {
     const {
-      res: { 
-        data: { 
-          access_token, 
-          token_type, 
-          expires_in, 
-          scope 
-        } 
+      res: {
+        data: { access_token, token_type, expires_in, scope },
       },
     } = ctx;
 
-    return { 
-      ...ctx, 
-      authToken: { 
-        access_token, 
-        token_type, 
-        expires_in, 
-        scope 
-      }  
+    return {
+      ...ctx,
+      authToken: {
+        access_token,
+        token_type,
+        expires_in,
+        scope,
+      },
     };
   }
 }

--- a/src/interceptors/add_multitenant_client_secret_to_params.js
+++ b/src/interceptors/add_multitenant_client_secret_to_params.js
@@ -1,0 +1,17 @@
+/**
+   Read `multitenantClientSecretToken` from `ctx` and add it as `client_secret`
+   to `params`.
+
+   Changes to `ctx`:
+
+   - add `params.client_secret`
+*/
+export default class AddMultitenantClientSecretToParams {
+  enter(ctx) {
+    const { multitenantClientSecretToken, params = {} } = ctx;
+    return {
+      ...ctx,
+      params: { ...params, client_secret: multitenantClientSecretToken },
+    };
+  }
+}

--- a/src/interceptors/add_multitenant_client_secret_token_to_ctx.js
+++ b/src/interceptors/add_multitenant_client_secret_token_to_ctx.js
@@ -1,0 +1,28 @@
+/**
+   Read `multitenantClientSecret` and `hostname` from `ctx`. Then construct a
+   signed JWT and add it to the context for use later in the interceptor chain.
+
+   Changes to `ctx`:
+
+   - Add `multitenantClientSecretToken`
+*/
+import jwt from 'jsonwebtoken';
+
+const signingOpts = {
+  algorithm: 'HS256',
+  expiresIn: 60, // seconds, should be enough for possible clock skew, but not too long
+};
+
+export default class AddMultitenantClientSecretTokenToCtx {
+  enter(ctx) {
+    const { multitenantClientSecret, hostname } = ctx;
+
+    const multitenantClientSecretToken = jwt.sign(
+      { hostname },
+      multitenantClientSecret,
+      signingOpts
+    );
+
+    return { ...ctx, multitenantClientSecretToken };
+  }
+}

--- a/src/jwt_mock.js
+++ b/src/jwt_mock.js
@@ -1,0 +1,12 @@
+/**
+   Mock empty implementation of jsonwebtoken's .sign() method.
+   This is used by webpack in browser build in order to avoid
+   the node-only dependency breaking builds downstream.
+*/
+const jwt = {
+  sign: (/* value, secret */) => {
+    throw new Error('JWT support not implemented.');
+  },
+};
+
+export default jwt;

--- a/src/multitenant_sdk.js
+++ b/src/multitenant_sdk.js
@@ -2,7 +2,8 @@ import _ from 'lodash';
 import { fnPath as urlPathToFnPath, trimEndSlash, formData } from './utils';
 import AddMultitenantAuthTokenResponse from './interceptors/add_multitenant_auth_token_response';
 import SaveToken from './interceptors/save_token';
-import AddClientSecretToParams from './interceptors/add_client_secret_to_params';
+import AddMultitenantClientSecretTokenToCtx from './interceptors/add_multitenant_client_secret_token_to_ctx';
+import AddMultitenantClientSecretToParams from './interceptors/add_multitenant_client_secret_to_params';
 import FormatHttpResponse from './interceptors/format_http_response';
 import endpointRequest from './interceptors/endpoint_request';
 import AddMultitenantAuthHeader from './interceptors/add_multitenant_auth_header';
@@ -14,12 +15,13 @@ import contextRunner from './context_runner';
 /* eslint-disable class-methods-use-this */
 
 const defaultSdkConfig = {
-  clientSecret: null,
+  hostname: null,
+  multitenantClientSecret: null,
   baseUrl: 'https://flex-api.sharetribe.com',
   adapter: null,
   version: 'v1',
   httpAgent: null,
-  httpsAgent: null
+  httpsAgent: null,
 };
 
 const multitenantAuthApi = [
@@ -48,9 +50,9 @@ const apis = {
 };
 
 const tokenInterceptors = (authApiEndpointInterceptors) => [
-  // TODO: encode secret as JWT
   new FormatHttpResponse(),
-  new AddClientSecretToParams(),
+  new AddMultitenantClientSecretTokenToCtx(),
+  new AddMultitenantClientSecretToParams(),
   new SaveToken(),
   new AddMultitenantAuthTokenResponse(),
   ..._.get(authApiEndpointInterceptors, 'token')
@@ -58,6 +60,7 @@ const tokenInterceptors = (authApiEndpointInterceptors) => [
 
 const clientDataInterceptors = (authApiEndpointInterceptors) => [
   new FormatHttpResponse(),
+  new AddMultitenantClientSecretTokenToCtx(),
   new AddMultitenantAuthHeader(),
   ..._.get(authApiEndpointInterceptors, 'clientData')
 ];
@@ -70,7 +73,7 @@ const tokenAndClientDataInterceptor = (authApiEndpointInterceptors) => (
           .then(tokenStore.getToken)
           .then(storedToken => {
             // If there's a token with any access, it's only necessary
-            // to fetch the client data. Else, we request a token and 
+            // to fetch the client data. Else, we request a token and
             // the response will also contain the client data.
             // We don't need to distinguish between token scopes.
             if (storedToken) {
@@ -89,7 +92,7 @@ const tokenAndClientDataInterceptor = (authApiEndpointInterceptors) => (
                   }
                 });
             }
-            
+
             return contextRunner(tokenInterceptors(authApiEndpointInterceptors))({
               ...ctx,
               params: { grant_type: 'multitenant_client_credentials' }
@@ -142,13 +145,17 @@ const authApiSdkFns = (authApiEndpointInterceptors, ctx) => [
 const transformSdkConfig = ({ baseUrl, tokenStore, ...sdkConfig }) => ({
   ...sdkConfig,
   baseUrl: trimEndSlash(baseUrl),
-  tokenStore: tokenStore || memoryStore()
+  tokenStore: tokenStore || memoryStore(),
 });
 
 // Validate SDK configurations, throw an error if invalid, otherwise return.
 const validateSdkConfig = sdkConfig => {
-  if (!sdkConfig.clientSecret) {
-    throw new Error('clientSecret must be provided');
+  if (!sdkConfig.hostname) {
+    throw new Error('hostname must be provided');
+  }
+
+  if (!sdkConfig.multitenantClientSecret) {
+    throw new Error('multitenantClientSecret must be provided');
   }
 
   if (!sdkConfig.baseUrl) {
@@ -158,8 +165,8 @@ const validateSdkConfig = sdkConfig => {
   /* global window */
   const isBrowser = typeof window !== 'undefined' && typeof window.document !== 'undefined';
 
-  if (isBrowser && sdkConfig.clientSecret) {
-    throw new Error('Using the client secret in a browser is not allowed.');
+  if (isBrowser) {
+    throw new Error('Using the multitenant SDK in browser is not allowed.');
   }
 
   return sdkConfig;
@@ -199,7 +206,8 @@ export default class MultitenantSharetribeSdk {
 
     const ctx = {
       endpointInterceptors: allEndpointInterceptors,
-      clientSecret: sdkConfig.clientSecret,
+      multitenantClientSecret: sdkConfig.multitenantClientSecret,
+      hostname: sdkConfig.hostname,
       tokenStore: sdkConfig.tokenStore,
     };
 

--- a/src/multitenant_sdk.test.js
+++ b/src/multitenant_sdk.test.js
@@ -56,7 +56,7 @@ const createSdk = (config = {}) => {
 describe('new MultitenantSharetribeSdk', () => {
   const validSdkConfig = {
     clientSecret: 'some-secret',
-    baseUrl: 'https://api-base-url.example'
+    baseUrl: 'https://api-base-url.example',
   };
 
   it('validates presence of clientSecret', () => {
@@ -81,23 +81,23 @@ describe('new MultitenantSharetribeSdk', () => {
         // Fake adapter that echoes the URL that was used in the request
         resolve({ data: { baseURL: config.baseURL } });
       });
-  
+
       const { baseUrl, ...withoutBaseUrl } = validSdkConfig;
-  
+
       const sdk = new MultitenantSharetribeSdk({
         ...withoutBaseUrl,
         adapter: adapter.adapterFn,
       });
-  
+
       return sdk.token().then(res => {
         expect(res.data.baseURL).toMatch(/^https:\/\/flex-api.sharetribe.com/);
       });
     });
-  
+
     it('stores auth token after token request', () => {
       const { sdk, sdkTokenStore } = createSdk();
       expect(sdkTokenStore.getToken()).toBeUndefined();
-  
+
       // Anonymous token is stored
       return report(
         sdk.token({ grant_type: 'multitenant_client_credentials' }).then(() => {
@@ -105,16 +105,16 @@ describe('new MultitenantSharetribeSdk', () => {
             access_token: 'anonymous-access-1',
             expires_in: 86400,
             scope: 'public-read',
-            token_type: 'bearer'
+            token_type: 'bearer',
           });
         })
       );
     });
-  
+
     it('token request returns unauthorized', () => {
       const { sdk, sdkTokenStore } = createSdk({ clientSecret: 'invalid' });
       expect(sdkTokenStore.getToken()).toBeUndefined();
-  
+
       // Anonymous token is stored
       return report(
         sdk.token({ grant_type: 'multitenant_client_credentials' }).catch(e => {
@@ -123,28 +123,27 @@ describe('new MultitenantSharetribeSdk', () => {
             expect.objectContaining({
               status: 401,
               statusText: 'Unauthorized',
-              data: 'Unauthorized'
+              data: 'Unauthorized',
             })
           );
         })
       );
     });
-  
+
     it('token request returns not found', () => {
       const { sdk } = createSdk({ clientSecret: 'valid-secret-invalid-hostname' });
-  
+
       return report(
-        sdk.token({ grant_type: 'multitenant_client_credentials' })
-          .catch(e => {
-            expect(e).toBeInstanceOf(Error);
-            expect(e).toEqual(
-              expect.objectContaining({
-                status: 404,
-                statusText: 'Not Found',
-                data: 'Not Found'
-              })
-            );
-          })
+        sdk.token({ grant_type: 'multitenant_client_credentials' }).catch(e => {
+          expect(e).toBeInstanceOf(Error);
+          expect(e).toEqual(
+            expect.objectContaining({
+              status: 404,
+              statusText: 'Not Found',
+              data: 'Not Found',
+            })
+          );
+        })
       );
     });
   });
@@ -163,7 +162,8 @@ describe('new MultitenantSharetribeSdk', () => {
             expect(authInfo.scopes).toBeUndefined();
           })
           .then(() =>
-            sdk.token({ grant_type: 'multitenant_client_credentials' })
+            sdk
+              .token({ grant_type: 'multitenant_client_credentials' })
               .then(sdk.authInfo)
               .then(authInfo => {
                 // Anonymous token
@@ -196,53 +196,49 @@ describe('new MultitenantSharetribeSdk', () => {
       const { sdk } = createSdk();
 
       return report(
-        sdk
-          .clientData()
-          .then(response => {
-            expect(response.data).toEqual(
-              expect.objectContaining({
-                client_id: '08ec69f6-d37e-414d-83eb-324e94afddf0'
-              })
-            );
-          })
+        sdk.clientData().then(response => {
+          expect(response.data).toEqual(
+            expect.objectContaining({
+              client_id: '08ec69f6-d37e-414d-83eb-324e94afddf0',
+            })
+          );
+        })
       );
     });
 
     it('client data request returns unauthorized', () => {
       const { sdk, sdkTokenStore } = createSdk({ clientSecret: 'invalid' });
       expect(sdkTokenStore.getToken()).toBeUndefined();
-  
+
       // Anonymous token is stored
       return report(
-        sdk.clientData()
-          .catch(e => {
-            expect(e).toBeInstanceOf(Error);
-            expect(e).toEqual(
-              expect.objectContaining({
-                status: 401,
-                statusText: 'Unauthorized',
-                data: 'Unauthorized'
-              })
-            );
-          })
-        );
+        sdk.clientData().catch(e => {
+          expect(e).toBeInstanceOf(Error);
+          expect(e).toEqual(
+            expect.objectContaining({
+              status: 401,
+              statusText: 'Unauthorized',
+              data: 'Unauthorized',
+            })
+          );
+        })
+      );
     });
-  
+
     it('client data request returns not found', () => {
       const { sdk } = createSdk({ clientSecret: 'valid-secret-invalid-hostname' });
-  
+
       return report(
-        sdk.clientData()
-          .catch(e => {
-            expect(e).toBeInstanceOf(Error);
-            expect(e).toEqual(
-              expect.objectContaining({
-                status: 404,
-                statusText: 'Not Found',
-                data: 'Not Found'
-              })
-            );
-          })
+        sdk.clientData().catch(e => {
+          expect(e).toBeInstanceOf(Error);
+          expect(e).toEqual(
+            expect.objectContaining({
+              status: 404,
+              statusText: 'Not Found',
+              data: 'Not Found',
+            })
+          );
+        })
       );
     });
   });
@@ -252,29 +248,27 @@ describe('new MultitenantSharetribeSdk', () => {
       const { sdk, sdkTokenStore } = createSdk();
 
       return report(
-        sdk
-          .clientAuthData()
-          .then(response => {
-            // token store contains relevant token information
-            expect(sdkTokenStore.getToken()).toEqual({
+        sdk.clientAuthData().then(response => {
+          // token store contains relevant token information
+          expect(sdkTokenStore.getToken()).toEqual({
+            access_token: 'anonymous-access-1',
+            expires_in: 86400,
+            scope: 'public-read',
+            token_type: 'bearer',
+          });
+          // response data contains access token and client data
+          expect(response.data).toEqual(
+            expect.objectContaining({
               access_token: 'anonymous-access-1',
-              expires_in: 86400,
-              scope: 'public-read',
-              token_type: 'bearer'
-            });
-            // response data contains access token and client data
-            expect(response.data).toEqual(
-              expect.objectContaining({
-                access_token: 'anonymous-access-1', 
-                client_data: {
-                  client_id: '08ec69f6-d37e-414d-83eb-324e94afddf0',
-                  // for testing purposes, called_url is not included in the real API response
-                  // Token endpoint is called
-                  called_url: "auth/multitenant/token"
-                },
-              })
-            );
-          })
+              client_data: {
+                client_id: '08ec69f6-d37e-414d-83eb-324e94afddf0',
+                // for testing purposes, called_url is not included in the real API response
+                // Token endpoint is called
+                called_url: 'auth/multitenant/token',
+              },
+            })
+          );
+        })
       );
     });
 
@@ -285,59 +279,55 @@ describe('new MultitenantSharetribeSdk', () => {
       sdkTokenStore.setToken({ ...rest });
 
       return report(
-        sdk
-          .clientAuthData()
-          .then(response => {
-            expect(response.data).toEqual(
-              expect.objectContaining({
-                access_token: 'anonymous-access-1', 
-                client_data: {
-                  client_id: '08ec69f6-d37e-414d-83eb-324e94afddf0',
-                  // for testing purposes, called_url is not included in the real API response
-                  // Client data endpoint is called
-                  called_url: "auth/multitenant/client_data"
-                },
-              })
-            );
-          })
+        sdk.clientAuthData().then(response => {
+          expect(response.data).toEqual(
+            expect.objectContaining({
+              access_token: 'anonymous-access-1',
+              client_data: {
+                client_id: '08ec69f6-d37e-414d-83eb-324e94afddf0',
+                // for testing purposes, called_url is not included in the real API response
+                // Client data endpoint is called
+                called_url: 'auth/multitenant/client_data',
+              },
+            })
+          );
+        })
       );
     });
 
     it('client data request returns unauthorized', () => {
       const { sdk, sdkTokenStore } = createSdk({ clientSecret: 'invalid' });
       expect(sdkTokenStore.getToken()).toBeUndefined();
-  
+
       // Anonymous token is stored
       return report(
-        sdk.clientAuthData()
-          .catch(e => {
-            expect(e).toBeInstanceOf(Error);
-            expect(e).toEqual(
-              expect.objectContaining({
-                status: 401,
-                statusText: 'Unauthorized',
-                data: 'Unauthorized'
-              })
-            );
-          })
-        );
+        sdk.clientAuthData().catch(e => {
+          expect(e).toBeInstanceOf(Error);
+          expect(e).toEqual(
+            expect.objectContaining({
+              status: 401,
+              statusText: 'Unauthorized',
+              data: 'Unauthorized',
+            })
+          );
+        })
+      );
     });
-  
+
     it('client data request returns not found', () => {
       const { sdk } = createSdk({ clientSecret: 'valid-secret-invalid-hostname' });
-  
+
       return report(
-        sdk.clientAuthData()
-          .catch(e => {
-            expect(e).toBeInstanceOf(Error);
-            expect(e).toEqual(
-              expect.objectContaining({
-                status: 404,
-                statusText: 'Not Found',
-                data: 'Not Found'
-              })
-            );
-          })
+        sdk.clientAuthData().catch(e => {
+          expect(e).toBeInstanceOf(Error);
+          expect(e).toEqual(
+            expect.objectContaining({
+              status: 404,
+              statusText: 'Not Found',
+              data: 'Not Found',
+            })
+          );
+        })
       );
     });
   });

--- a/src/multitenant_sdk.test.js
+++ b/src/multitenant_sdk.test.js
@@ -29,7 +29,8 @@ const report = responsePromise =>
  */
 const createSdk = (config = {}) => {
   const defaults = {
-    clientSecret: 'valid-secret-valid-hostname',
+    multitenantClientSecret: 'valid-secret',
+    hostname: 'valid.example.com',
   };
 
   // Extract adapter and token store here so that they can be passed to SDK
@@ -55,14 +56,15 @@ const createSdk = (config = {}) => {
 
 describe('new MultitenantSharetribeSdk', () => {
   const validSdkConfig = {
-    clientSecret: 'some-secret',
+    multitenantClientSecret: 'valid-secret',
+    hostname: 'valid.example.com',
     baseUrl: 'https://api-base-url.example',
   };
 
   it('validates presence of clientSecret', () => {
-    const { clientSecret, ...withoutClientSecretConfig } = validSdkConfig;
+    const { multitenantClientSecret, ...withoutClientSecretConfig } = validSdkConfig;
     expect(() => new MultitenantSharetribeSdk(withoutClientSecretConfig)).toThrowError(
-      'clientSecret must be provided'
+      'multitenantClientSecret must be provided'
     );
   });
 
@@ -112,7 +114,10 @@ describe('new MultitenantSharetribeSdk', () => {
     });
 
     it('token request returns unauthorized', () => {
-      const { sdk, sdkTokenStore } = createSdk({ clientSecret: 'invalid' });
+      const { sdk, sdkTokenStore } = createSdk({
+        multitenantClientSecret: 'invalid-secret',
+        hostname: 'valid.example.com',
+      });
       expect(sdkTokenStore.getToken()).toBeUndefined();
 
       // Anonymous token is stored

--- a/webpack.config.babel.js
+++ b/webpack.config.babel.js
@@ -30,6 +30,7 @@ const nodeConfig = {
   module,
   externals: [
     'axios',
+    'jsonwebtoken'
   ],
 };
 
@@ -42,6 +43,14 @@ const webConfig = {
   plugins: [
     new webpack.optimize.UglifyJsPlugin(),
   ],
+  resolve: {
+    alias: {
+      // JWT is mocked with empty implementation in the browser build as it is
+      // not needed there and this prevents downstream webpack runs from
+      // attemtpting to include the dependency.
+      jsonwebtoken: path.resolve(__dirname, 'src/jwt_mock.js')
+    }
+  }
 };
 
 export default () => ([nodeConfig, webConfig]);

--- a/yarn.lock
+++ b/yarn.lock
@@ -1882,6 +1882,11 @@ bser@^2.0.0:
   dependencies:
     node-int64 "^0.4.0"
 
+buffer-equal-constant-time@1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz#f8e71132f7ffe6e01a5c9697a4c6f3e48d5cc819"
+  integrity sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==
+
 buffer-from@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.1.tgz#32713bc028f75c02fdb710d7c7bcec1f2c6070ef"
@@ -2995,6 +3000,13 @@ ecc-jsbn@~0.1.1:
   dependencies:
     jsbn "~0.1.0"
     safer-buffer "^2.1.0"
+
+ecdsa-sig-formatter@1.0.11:
+  version "1.0.11"
+  resolved "https://registry.yarnpkg.com/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz#ae0f0fa2d85045ef14a817daa3ce9acd0489e5bf"
+  integrity sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==
+  dependencies:
+    safe-buffer "^5.0.1"
 
 ee-first@1.1.1:
   version "1.1.1"
@@ -5280,6 +5292,16 @@ jsonparse@^1.2.0:
   resolved "https://registry.yarnpkg.com/jsonparse/-/jsonparse-1.3.1.tgz#3f4dae4a91fac315f71062f8521cc239f1366280"
   integrity sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA=
 
+jsonwebtoken@^9.0.0:
+  version "9.0.0"
+  resolved "https://registry.yarnpkg.com/jsonwebtoken/-/jsonwebtoken-9.0.0.tgz#d0faf9ba1cc3a56255fe49c0961a67e520c1926d"
+  integrity sha512-tuGfYXxkQGDPnLJ7SibiQgVgeDgfbPq2k2ICcbgqW8WxWLBAxKQM/ZCu/IT8SOSwmaYl4dpTFCW5xZv7YbbWUw==
+  dependencies:
+    jws "^3.2.2"
+    lodash "^4.17.21"
+    ms "^2.1.1"
+    semver "^7.3.8"
+
 jsprim@^1.2.2:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/jsprim/-/jsprim-1.4.1.tgz#313e66bc1e5cc06e438bc1b7499c2e5c56acb6a2"
@@ -5304,6 +5326,23 @@ jstransformer@1.0.0:
   dependencies:
     is-promise "^2.0.0"
     promise "^7.0.1"
+
+jwa@^1.4.1:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/jwa/-/jwa-1.4.1.tgz#743c32985cb9e98655530d53641b66c8645b039a"
+  integrity sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==
+  dependencies:
+    buffer-equal-constant-time "1.0.1"
+    ecdsa-sig-formatter "1.0.11"
+    safe-buffer "^5.0.1"
+
+jws@^3.2.2:
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/jws/-/jws-3.2.2.tgz#001099f3639468c9414000e99995fa52fb478304"
+  integrity sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==
+  dependencies:
+    jwa "^1.4.1"
+    safe-buffer "^5.0.1"
 
 kind-of@^3.0.2, kind-of@^3.0.3, kind-of@^3.2.0:
   version "3.2.2"
@@ -5596,7 +5635,7 @@ lodash.values@^2.4.1:
   dependencies:
     lodash.keys "~2.4.1"
 
-lodash@^3.10.1, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.4, lodash@^4.17.5:
+lodash@^3.10.1, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.21, lodash@^4.17.4, lodash@^4.17.5:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
@@ -5633,6 +5672,13 @@ lru-cache@^4.0.1, lru-cache@^4.1.3:
   dependencies:
     pseudomap "^1.0.2"
     yallist "^2.1.2"
+
+lru-cache@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-6.0.0.tgz#6d6fe6570ebd96aaf90fcad1dafa3b2566db3a94"
+  integrity sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==
+  dependencies:
+    yallist "^4.0.0"
 
 make-dir@^1.0.0:
   version "1.3.0"
@@ -7635,6 +7681,13 @@ semver@^6.0.0, semver@^6.2.0, semver@^6.3.0:
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
   integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
 
+semver@^7.3.8:
+  version "7.3.8"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.8.tgz#07a78feafb3f7b32347d725e33de7e2a2df67798"
+  integrity sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==
+  dependencies:
+    lru-cache "^6.0.0"
+
 set-blocking@^2.0.0, set-blocking@~2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/set-blocking/-/set-blocking-2.0.0.tgz#045f9782d011ae9a6803ddd382b24392b3d890f7"
@@ -9056,6 +9109,11 @@ yallist@^3.0.0, yallist@^3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-3.1.1.tgz#dbb7daf9bfd8bac9ab45ebf602b8cbad0d5d08fd"
   integrity sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==
+
+yallist@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/yallist/-/yallist-4.0.0.tgz#9bb92790d9c0effec63be73519e11a35019a3a72"
+  integrity sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==
 
 yargs-parser@^10.0.0:
   version "10.1.0"


### PR DESCRIPTION
Add interceptor that produces signed JWT in place of a `client_secret` in multitenant API calls.

Renames multitenant SDK's `clientSecret` to `multitenantClientSecret` for clarity and to avoid possible internal conflict / mistakes. Adds new config `hostname`, which will be the multitenant identifying bit.

The `jsonwebtoken` dependency is node-only. More, we don't need it in browser side anyway, so we mock it out in browser build. That allows downstream apps to use the SDK without modifying their webpack config and having to handle `jsonwebtoken` or this SDK in a special way.