### PR TITLE
Support absolute paths

### DIFF
--- a/src/sdk.js
+++ b/src/sdk.js
@@ -285,7 +285,7 @@ const assetsApiSdkFns = (assetsEndpointInterceptors, ctx) => [
         pathParams: {
           clientId: ctx.clientId,
           alias: alias || 'latest',
-          assetPath: path,
+          assetPath: path[0] === '/' ? path.slice(1) : path,
         },
         interceptors: [new FormatHttpResponse(), ..._.get(assetsEndpointInterceptors, 'byAlias')],
       });
@@ -308,7 +308,7 @@ const assetsApiSdkFns = (assetsEndpointInterceptors, ctx) => [
         pathParams: {
           clientId: ctx.clientId,
           version,
-          assetPath: path,
+          assetPath: path[0] === '/' ? path.slice(1) : path,
         },
         interceptors: [new FormatHttpResponse(), ..._.get(assetsEndpointInterceptors, 'byVersion')],
       });

--- a/src/sdk.test.js
+++ b/src/sdk.test.js
@@ -1029,11 +1029,46 @@ describe('asset', () => {
     );
   });
 
+  it('returns latest asset with absolute path', () => {
+    const { sdk } = createSdk();
+
+    return report(
+      sdk.assetByAlias({ path: '/translations.json', alias: 'latest' }).then(res => {
+        const resource = res.data.data;
+        const { version } = res.data.meta;
+
+        expect(resource).toEqual({
+          'navigation.listings': 'Listings',
+          'navigation.account': 'My account',
+          'navigation.login': 'Log in',
+        });
+        expect(version).toEqual('v3');
+      })
+    );
+  });
+
   it('returns asset by version', () => {
     const { sdk } = createSdk();
 
     return report(
       sdk.assetByVersion({ path: 'translations.json', version: 'v2' }).then(res => {
+        const resource = res.data.data;
+        const { version } = res.data.meta;
+
+        expect(resource).toEqual({
+          'navigation.listings': 'Listings',
+          'navigation.account': 'My account',
+        });
+        expect(version).toEqual('v2');
+      })
+    );
+  });
+
+  it('returns asset with absolute path by version', () => {
+    const { sdk } = createSdk();
+
+    return report(
+      sdk.assetByVersion({ path: '/translations.json', version: 'v2' }).then(res => {
         const resource = res.data.data;
         const { version } = res.data.meta;
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -104,7 +104,7 @@ const longestPathPrefix = (sortedPathParts, result = '') => {
      }
 */
 export const canonicalAssetPaths = paths => {
-  const sortedPaths = [...new Set(paths)].map(p => (p[0] === '/' ? p.slice[1] : p)).sort();
+  const sortedPaths = [...new Set(paths)].map(p => (p[0] === '/' ? p.slice(1) : p)).sort();
   const sortedPathParts = [...sortedPaths].map(p => p.split('/'));
   const pathPrefix = longestPathPrefix(sortedPathParts);
   const prefixLength = pathPrefix.length;

--- a/src/utils.test.js
+++ b/src/utils.test.js
@@ -97,6 +97,19 @@ describe('utils', () => {
         relativePaths: ['nested/page-d.json', 'page-a.json', 'page-b.json', 'page-c.json'],
       });
     });
+    it('can handle absolute paths', () => {
+      expect(
+        canonicalAssetPaths([
+          'content/pages/blog/page-b.json',
+          '/content/pages/blog/page-a.json',
+          '/content/pages/blog/page-c.json',
+          'content/pages/blog/nested/page-d.json',
+        ])
+      ).toEqual({
+        pathPrefix: 'content/pages/blog/',
+        relativePaths: ['nested/page-d.json', 'page-a.json', 'page-b.json', 'page-c.json'],
+      });
+    });
     it('no common path prefix is found', () => {
       expect(
         canonicalAssetPaths(['content/pages/main.json', 'settings/admin.json', 'other/any.json'])


### PR DESCRIPTION
Fixes bug preventing support for absolute paths in the new multi-asset fetching APIs. Also changes the existing `assetByAlias` and `assetByVersion` SDK APIs to support absolute paths.