### PR TITLE
Add loginWithIdp method to multitenant SDK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 ### Changed
 
 - Remove references to Flex in documentation. [190](https://github.com/sharetribe/flex-sdk-js/pull/190)
+- Internal changes [#192](https://github.com/sharetribe/flex-sdk-js/pull/192)
 
 ## [v1.20.0] - 2023-10-10
 

--- a/src/fake/adapter.js
+++ b/src/fake/adapter.js
@@ -106,6 +106,8 @@ const authApiHandler = (config, resolve, reject, tokenStore) => {
       return auth.multitenantAuthData(config, resolve, reject, tokenStore);
     case 'auth/multitenant/client_data':
       return auth.multitenantClientData(config, resolve, reject);
+    case 'auth/multitenant/auth_with_idp':
+      return auth.multitenantAuthWithIdpData(config, resolve, reject, tokenStore);
     default:
       throw new Error(`No fake adapter handler implemented for Auth API endpoint: ${config.url}`);
   }

--- a/src/fake/auth.js
+++ b/src/fake/auth.js
@@ -171,3 +171,34 @@ export const authWithIdp = (config, resolve, reject, fakeTokenStore) => {
     __additionalTestInfo: { formData },
   });
 };
+
+export const multitenantAuthWithIdpData = (config, resolve, reject, fakeTokenStore) => {
+  const formData = parseFormData(config.data);
+  const { idpId, idpClientId, idpToken } = formData;
+  let success;
+  let error = {
+    status: 401,
+    statusText: 'Unauthorized',
+    data: 'Unauthorized',
+  };
+
+  const hostname = hostnameFromToken(formData.client_secret, 'valid-secret');
+
+  if (hostname === 'valid.example.com') {
+    success = fakeTokenStore.createTokenWithIdp(idpId, idpClientId, idpToken);
+  } else if (hostname === 'invalid.example.com') {
+    error = {
+      ...error,
+      status: 404,
+      statusText: 'Not Found',
+      data: 'Not Found',
+      headers: { 'content-type': 'text/plain' },
+    };
+  }
+
+  if (success) {
+    return resolve({ data: JSON.stringify(success) });
+  }
+
+  return reject(error);
+};

--- a/src/interceptors/add_multitenant_auth_with_idp_response.js
+++ b/src/interceptors/add_multitenant_auth_with_idp_response.js
@@ -1,0 +1,29 @@
+/**
+   Take token data from `res` and add it to `ctx` top-level.
+   Make sure to include only the necessary keys.
+
+   Changes to `ctx`:
+
+   - add `authToken`
+*/
+export default class AddMultitenantAuthWithIdpResponse {
+  /* eslint camelcase: "off" */
+  leave(ctx) {
+    const {
+      res: {
+        data: { access_token, refresh_token, token_type, expires_in, scope },
+      },
+    } = ctx;
+
+    return {
+      ...ctx,
+      authToken: {
+        access_token,
+        refresh_token,
+        token_type,
+        expires_in,
+        scope,
+      },
+    };
+  }
+}


### PR DESCRIPTION
Adds a multitenant `loginWithIdp` method that invokes the `/auth/multitenant/auth_with_idp` endpoint which allows obtaining an access token by using multitenant client token and IdP credentials.