### PR TITLE
Is logged in as

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,25 @@ adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased] - xxxx-xx-xx
 
+### Added
+
+- Add a new function `loginAs`. The function takes a single parameter, `code`,
+  which is the authorization code to use. This function should be used to do
+  "Login As" instead of using `login` function with `code`.
+  [#196](https://github.com/sharetribe/flex-sdk-js/pull/196)
+- Add a new key `isLoggedInAs` to the return value of the `authInfo`. The value
+  is boolean where `true` indicates that "Login As" was used. Applications
+  should use this value to check if "Login As" was used instead of examining the
+  token scopes. [#196](https://github.com/sharetribe/flex-sdk-js/pull/196)
+- Add a new configuration option `disableDeprecationWarnings`
+  [#196](https://github.com/sharetribe/flex-sdk-js/pull/196)
+
+### Deprecated
+
+- Using the `login` function to do "Login As", i.e. logging in with `code`
+  instead of `username` and `password` is deprecated in favor of a newly added
+  `loginAs` function. [#196](https://github.com/sharetribe/flex-sdk-js/pull/196)
+
 ## [v1.20.1] - 2024-02-15
 
 ### Fixed

--- a/docs/configurations.md
+++ b/docs/configurations.md
@@ -95,7 +95,12 @@ var sdk = sharetribeSdk.createInstance({
   // but if you know what you are doing, and you have secured the website properly so
   // that Client Secret is not leaked, you can suppress the warning by setting this
   // to `true`.
-  dangerouslyAllowClientSecretInBrowser: false
+  dangerouslyAllowClientSecretInBrowser: false,
 
+  // Disables deprecation warnings.
+  //
+  // Deprecation warnings are printed with `console.warn` if `console.warn`
+  // is available. Setting this value to `true` will suppress those warnings.
+  disableDeprecationWarnings: false
 });
 ```

--- a/src/fake/token_store.js
+++ b/src/fake/token_store.js
@@ -202,6 +202,7 @@ const createTokenStore = () => {
           refresh_token: generateRefreshToken(username),
           token_type: 'bearer',
           expires_in: 86400,
+          // TODO missing `scope`
         },
         user: {
           username,

--- a/src/interceptors/add_authorization_code_grant_type_to_params.js
+++ b/src/interceptors/add_authorization_code_grant_type_to_params.js
@@ -1,0 +1,13 @@
+/**
+   Add `authorization_code` value to `params.grantType`
+
+   Changes to `ctx`:
+
+   - Add `authorization_code` value to `params.grantType`
+ */
+
+export default class AddAuthorizationCodeGrantTypeToParams {
+  enter({ params, ...ctx }) {
+    return { ...ctx, params: { grant_type: 'authorization_code', ...params } };
+  }
+}

--- a/src/interceptors/add_grant_type_to_params.js
+++ b/src/interceptors/add_grant_type_to_params.js
@@ -6,6 +6,9 @@
 
    - add `params.grant_type`
  */
+
+import { deprecated } from '../utils';
+
 export default class AddGrantTypeToParams {
   enter({ params, ...ctx }) {
     const { username, password, code } = params;
@@ -15,6 +18,11 @@ export default class AddGrantTypeToParams {
     }
 
     if (code) {
+      deprecated(
+        'Using sdk.login to login as a user is deprecated. Use sdk.loginAs instead.',
+        ctx.disableDeprecationWarnings
+      );
+
       return { ...ctx, params: { grant_type: 'authorization_code', ...params } };
     }
 

--- a/src/interceptors/add_is_logged_in_as_to_context.js
+++ b/src/interceptors/add_is_logged_in_as_to_context.js
@@ -1,0 +1,20 @@
+/**
+   See if `code` is passed as a parameter and if yes, store isLoggedInAs true to
+   context.
+
+   Changes to `ctx`:
+
+   - add `isLoggedInAs`
+ */
+
+export default class AddIsLoggedInAsToContext {
+  enter(ctx) {
+    const { code } = ctx.params;
+
+    if (code) {
+      return { ...ctx, isLoggedInAs: !!code };
+    }
+
+    return ctx;
+  }
+}

--- a/src/interceptors/add_is_logged_in_as_to_context.js
+++ b/src/interceptors/add_is_logged_in_as_to_context.js
@@ -1,6 +1,5 @@
 /**
-   See if `code` is passed as a parameter and if yes, store isLoggedInAs true to
-   context.
+   Add isLoggedInAs true to context.
 
    Changes to `ctx`:
 
@@ -9,12 +8,6 @@
 
 export default class AddIsLoggedInAsToContext {
   enter(ctx) {
-    const { code } = ctx.params;
-
-    if (code) {
-      return { ...ctx, isLoggedInAs: !!code };
-    }
-
-    return ctx;
+    return { ...ctx, isLoggedInAs: true };
   }
 }

--- a/src/interceptors/add_is_logged_in_as_to_context_from_params.js
+++ b/src/interceptors/add_is_logged_in_as_to_context_from_params.js
@@ -1,0 +1,22 @@
+/**
+   See if `code` is passed as a parameter and if yes, store isLoggedInAs true to
+   context.
+
+   Changes to `ctx`:
+
+   - add `isLoggedInAs`
+
+   Deprecated: login as user should use loginAs method.
+ */
+
+export default class AddIsLoggedInAsToContextFromParams {
+  enter(ctx) {
+    const { code } = ctx.params;
+
+    if (code) {
+      return { ...ctx, isLoggedInAs: !!code };
+    }
+
+    return ctx;
+  }
+}

--- a/src/interceptors/auth_info.js
+++ b/src/interceptors/auth_info.js
@@ -5,7 +5,8 @@
    - scopes: list of scopes associated with the access token in store
    - isAnonymous: boolean value indicating if the access token only grants
      access to publicly read data from API
-
+   - isLoggedInAs: boolean value indicating that the operator has logged in as
+     a marketplace user
 
    Changes to `ctx`:
 
@@ -22,6 +23,7 @@ export default class AuthInfo {
         .then(storedToken => {
           if (storedToken) {
             const tokenScope = storedToken.scope;
+            const { isLoggedInAs } = storedToken;
 
             if (tokenScope) {
               const scopes = tokenScope.split(' ');
@@ -31,14 +33,17 @@ export default class AuthInfo {
               // that rely on this attribute
               const grantType = isAnonymous ? 'client_credentials' : 'refresh_token';
 
-              return { ...ctx, res: { scopes, isAnonymous, grantType } };
+              return {
+                ...ctx,
+                res: { scopes, isAnonymous, grantType, isLoggedInAs: !!isLoggedInAs },
+              };
             }
 
             // Support old tokens that are stored in the client's token store
             // and possibly do not have the scope attribute
             const isAnonymous = !storedToken.refresh_token;
             const grantType = isAnonymous ? 'client_credentials' : 'refresh_token';
-            return { ...ctx, res: { isAnonymous, grantType } };
+            return { ...ctx, res: { isAnonymous, grantType, isLoggedInAs: !!isLoggedInAs } };
           }
 
           return { ...ctx, res: {} };

--- a/src/interceptors/save_token.js
+++ b/src/interceptors/save_token.js
@@ -1,5 +1,7 @@
 /**
-   On `leave` phase, take `authToken` from `ctx` and save it to tokenStore
+   On `leave` phase, take `authToken` from `ctx` and save it to tokenStore.
+
+   Stores also the `isLoggedInAs` alongside with the auth token.
 
    Changes to `ctx`:
 
@@ -7,11 +9,11 @@
 */
 export default class SaveToken {
   leave(ctx) {
-    const { authToken, tokenStore } = ctx;
+    const { authToken, tokenStore, isLoggedInAs } = ctx;
 
     if (tokenStore) {
       return Promise.resolve()
-        .then(() => tokenStore.setToken(authToken))
+        .then(() => tokenStore.setToken({ ...authToken, isLoggedInAs }))
         .then(() => ctx);
     }
 

--- a/src/sdk.js
+++ b/src/sdk.js
@@ -18,6 +18,7 @@ import FetchAuthTokenFromStore from './interceptors/fetch_auth_token_from_store'
 import AddClientIdToParams from './interceptors/add_client_id_to_params';
 import AddClientSecretToParams from './interceptors/add_client_secret_to_params';
 import AddSubjectTokenToParams from './interceptors/add_subject_token_to_params';
+import AddIsLoggedInAsToContext from './interceptors/add_is_logged_in_as_to_context';
 import AddGrantTypeToParams from './interceptors/add_grant_type_to_params';
 import AddTokenExchangeGrantTypeToParams from './interceptors/add_token_exchange_grant_type_to_params';
 import AddScopeToParams from './interceptors/add_scope_to_params';
@@ -122,6 +123,7 @@ const authenticateInterceptors = [
 const loginInterceptors = [
   new AddClientIdToParams(),
   new AddGrantTypeToParams(),
+  new AddIsLoggedInAsToContext(),
   new AddScopeToParams(),
   new SaveToken(),
   new AddAuthTokenResponse(),

--- a/src/sdk.js
+++ b/src/sdk.js
@@ -18,8 +18,10 @@ import FetchAuthTokenFromStore from './interceptors/fetch_auth_token_from_store'
 import AddClientIdToParams from './interceptors/add_client_id_to_params';
 import AddClientSecretToParams from './interceptors/add_client_secret_to_params';
 import AddSubjectTokenToParams from './interceptors/add_subject_token_to_params';
+import AddIsLoggedInAsToContextFromParams from './interceptors/add_is_logged_in_as_to_context_from_params';
 import AddIsLoggedInAsToContext from './interceptors/add_is_logged_in_as_to_context';
 import AddGrantTypeToParams from './interceptors/add_grant_type_to_params';
+import AddAuthorizationCodeGrantTypeToParams from './interceptors/add_authorization_code_grant_type_to_params';
 import AddTokenExchangeGrantTypeToParams from './interceptors/add_token_exchange_grant_type_to_params';
 import AddScopeToParams from './interceptors/add_scope_to_params';
 import AuthInfo from './interceptors/auth_info';
@@ -46,6 +48,7 @@ const defaultSdkConfig = {
   httpAgent: null,
   httpsAgent: null,
   transitVerbose: false,
+  disableDeprecationWarnings: false,
 };
 
 /**
@@ -123,8 +126,16 @@ const authenticateInterceptors = [
 const loginInterceptors = [
   new AddClientIdToParams(),
   new AddGrantTypeToParams(),
-  new AddIsLoggedInAsToContext(),
+  new AddIsLoggedInAsToContextFromParams(),
   new AddScopeToParams(),
+  new SaveToken(),
+  new AddAuthTokenResponse(),
+];
+
+const loginAsInterceptors = [
+  new AddClientIdToParams(),
+  new AddAuthorizationCodeGrantTypeToParams(),
+  new AddIsLoggedInAsToContext(),
   new SaveToken(),
   new AddAuthTokenResponse(),
 ];
@@ -225,6 +236,17 @@ const authApiSdkFns = (authApiEndpointInterceptors, ctx) => [
       interceptors: [
         new FormatHttpResponse(),
         ...loginInterceptors,
+        ..._.get(authApiEndpointInterceptors, 'token'),
+      ],
+    }),
+  },
+  {
+    path: 'loginAs',
+    fn: createAuthApiSdkFn({
+      ctx,
+      interceptors: [
+        new FormatHttpResponse(),
+        ...loginAsInterceptors,
         ..._.get(authApiEndpointInterceptors, 'token'),
       ],
     }),
@@ -506,6 +528,7 @@ export default class SharetribeSdk {
       clientSecret: sdkConfig.clientSecret,
       typeHandlers: sdkConfig.typeHandlers,
       transitVerbose: sdkConfig.transitVerbose,
+      disableDeprecationWarnings: sdkConfig.disableDeprecationWarnings,
     };
 
     // Assign SDK functions to 'this'

--- a/src/sdk.test.js
+++ b/src/sdk.test.js
@@ -34,6 +34,10 @@ const report = responsePromise =>
 const createSdk = (config = {}) => {
   const defaults = {
     clientId: '08ec69f6-d37e-414d-83eb-324e94afddf0',
+
+    // We do want to test that also deprecated function work, so disable
+    // deprecation warnings to keep output clean.
+    disableDeprecationWarnings: true,
   };
 
   // Extract adapter and token store here so that they can be passed to SDK
@@ -418,10 +422,20 @@ describe('new SharetribeSdk', () => {
     );
   });
 
-  it('logs in with an authorization code', () => {
+  it('deprecated: logs in with an authorization code', () => {
     const { sdk, sdkTokenStore } = createSdk();
 
     return sdk.login({ code: 'flex-authorization-code' }).then(() => {
+      const { access_token, refresh_token } = sdkTokenStore.getToken();
+      expect(access_token).toEqual('joe.dunphy@example.com-access-1');
+      expect(refresh_token).toEqual('joe.dunphy@example.com-refresh-1');
+    });
+  });
+
+  it('logs in with an authorization code', () => {
+    const { sdk, sdkTokenStore } = createSdk();
+
+    return sdk.loginAs({ code: 'flex-authorization-code' }).then(() => {
       const { access_token, refresh_token } = sdkTokenStore.getToken();
       expect(access_token).toEqual('joe.dunphy@example.com-access-1');
       expect(refresh_token).toEqual('joe.dunphy@example.com-refresh-1');
@@ -788,6 +802,25 @@ describe('new SharetribeSdk', () => {
               .login({ code: 'flex-authorization-code' })
               .then(sdk.authInfo)
               .then(authInfo => {
+                // deprecated: Login as
+
+                // deprecated: grantType
+                // Please note that the value is also off. Token
+                // hasn't been refreshed, thus, grantType should be
+                // authorization_code
+                expect(authInfo.grantType).toEqual('refresh_token');
+
+                expect(authInfo.isAnonymous).toEqual(false);
+                expect(authInfo.scopes).toEqual(['user:limited']);
+                expect(authInfo.isLoggedInAs).toEqual(true);
+              })
+          )
+          .then(() =>
+            sdk
+              .loginAs({ code: 'flex-authorization-code' })
+              .then(sdk.authInfo)
+              .then(authInfo => {
+                // Login as
 
                 // deprecated: grantType
                 // Please note that the value is also off. Token

--- a/src/sdk.test.js
+++ b/src/sdk.test.js
@@ -741,9 +741,13 @@ describe('new SharetribeSdk', () => {
           .authInfo()
           .then(authInfo => {
             // No auth info yet.
+
+            // deprecated: grantType
             expect(authInfo.grantType).toBeUndefined();
+
             expect(authInfo.isAnonymous).toBeUndefined();
             expect(authInfo.scopes).toBeUndefined();
+            expect(authInfo.isLoggedInAs).toBeUndefined();
           })
           .then(() =>
             sdk.marketplace
@@ -751,9 +755,12 @@ describe('new SharetribeSdk', () => {
               .then(sdk.authInfo)
               .then(authInfo => {
                 // Anonymous token
+
+                // deprecated: grantType
                 expect(authInfo.grantType).toEqual('client_credentials');
                 expect(authInfo.isAnonymous).toEqual(true);
                 expect(authInfo.scopes).toEqual(['public-read']);
+                expect(authInfo.isLoggedInAs).toEqual(false);
               })
           )
           .then(() =>
@@ -765,9 +772,32 @@ describe('new SharetribeSdk', () => {
               .then(sdk.authInfo)
               .then(authInfo => {
                 // Login token
+
+                // deprecated: grantType
+                // Please note that the value is also off. Token
+                // hasn't been refreshed, thus, grantType should be password
                 expect(authInfo.grantType).toEqual('refresh_token');
+
                 expect(authInfo.isAnonymous).toEqual(false);
                 expect(authInfo.scopes).toEqual(['user']);
+                expect(authInfo.isLoggedInAs).toEqual(false);
+              })
+          )
+          .then(() =>
+            sdk
+              .login({ code: 'flex-authorization-code' })
+              .then(sdk.authInfo)
+              .then(authInfo => {
+
+                // deprecated: grantType
+                // Please note that the value is also off. Token
+                // hasn't been refreshed, thus, grantType should be
+                // authorization_code
+                expect(authInfo.grantType).toEqual('refresh_token');
+
+                expect(authInfo.isAnonymous).toEqual(false);
+                expect(authInfo.scopes).toEqual(['user:limited']);
+                expect(authInfo.isLoggedInAs).toEqual(true);
               })
           )
           .then(() =>
@@ -776,9 +806,13 @@ describe('new SharetribeSdk', () => {
               .then(sdk.authInfo)
               .then(authInfo => {
                 // Logout
+
+                // deprecated: grantType
                 expect(authInfo.grantType).toBeUndefined();
+
                 expect(authInfo.isAnonymous).toBeUndefined();
                 expect(authInfo.scopes).toBeUndefined();
+                expect(authInfo.isLoggedInAs).toBeUndefined();
               })
           )
           .then(() =>
@@ -787,9 +821,13 @@ describe('new SharetribeSdk', () => {
               .then(sdk.authInfo)
               .then(authInfo => {
                 // Logging out already logged out user does nothing
+
+                // deprecated: grantType
                 expect(authInfo.grantType).toBeUndefined();
+
                 expect(authInfo.isAnonymous).toBeUndefined();
                 expect(authInfo.scopes).toBeUndefined();
+                expect(authInfo.isLoggedInAs).toBeUndefined();
               })
           )
       );

--- a/src/utils.js
+++ b/src/utils.js
@@ -112,3 +112,13 @@ export const canonicalAssetPaths = paths => {
 
   return { pathPrefix, relativePaths };
 };
+
+const consoleAvailable = typeof console !== 'undefined';
+
+export const deprecated = (msg, disable) => {
+  /* eslint-disable no-console */
+  /* eslint-disable no-undef */
+  if (consoleAvailable && console.warn && !disable) {
+    console.warn(msg);
+  }
+};


### PR DESCRIPTION
In this PR:

- Add `isLoggedInAs` key to `authInfo` return value
- Add `loginAs` function
- Deprecate using `login` with `code` in favor of `loginAs`

Why? We are planning change the login as feature so that in test/dev marketplaces we'll issue token with `user` scope instead of `user:limited` (i.e. full access). Thus we can't anymore [rely on scope check](https://github.com/sharetribe/web-template/blob/01378972594cd93c5ddd65d1bb84925ea617b8a4/src/components/LimitedAccessBanner/LimitedAccessBanner.js#L32) to define whether we are normal user or using login as feature.