### PR TITLE
Fix Object with 'length' key bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased] - xxxx-xx-xx
 
+### Fixed
+
+- Bug: SDK failed to send any extended data if it had a key `length` with a
+  number type value. [#199](https://github.com/sharetribe/flex-sdk-js/pull/199)
+
 ## [v1.21.0] - 2024-05-20
 
 ### Added

--- a/src/interceptors/multipart_request.js
+++ b/src/interceptors/multipart_request.js
@@ -18,7 +18,7 @@ export default class MultipartRequest {
         );
       }
 
-      const formDataObj = entries(v).reduce((fd, entry) => {
+      const formDataObj = entries(params).reduce((fd, entry) => {
         const [val, key] = entry;
         fd.append(key, val);
         return fd;

--- a/src/interceptors/multipart_request.js
+++ b/src/interceptors/multipart_request.js
@@ -1,4 +1,5 @@
 import _ from 'lodash';
+import { entries } from '../utils';
 
 /**
    Takes `params` from `ctx` and converts to `FormData`
@@ -17,14 +18,11 @@ export default class MultipartRequest {
         );
       }
 
-      const formDataObj = _.reduce(
-        params,
-        (fd, val, key) => {
-          fd.append(key, val);
-          return fd;
-        },
-        new FormData()
-      );
+      const formDataObj = entries(v).reduce((fd, entry) => {
+        const [val, key] = entry;
+        fd.append(key, val);
+        return fd;
+      }, new FormData());
       /* eslint-enable no-undef */
 
       return { params: formDataObj, ...ctx };

--- a/src/serializer.js
+++ b/src/serializer.js
@@ -3,6 +3,7 @@
 import transit from 'transit-js';
 import _ from 'lodash';
 import { UUID, LatLng, Money, BigDecimal, toType } from './types';
+import { entries } from './utils';
 
 /**
    Composes two readers (sdk type and app type) so that:
@@ -168,14 +169,11 @@ const MapHandler = [
   transit.makeWriteHandler({
     tag: () => 'map',
     rep: v =>
-      _.reduce(
-        v,
-        (map, val, key) => {
-          map.set(transit.keyword(key), val);
-          return map;
-        },
-        transit.map()
-      ),
+      entries(v).reduce((map, entry) => {
+        const [key, val] = entry;
+        map.set(transit.keyword(key), val);
+        return map;
+      }, transit.map()),
   }),
 ];
 

--- a/src/serializer.test.js
+++ b/src/serializer.test.js
@@ -19,6 +19,24 @@ describe('serializer', () => {
     expect(r.read(w.write(testData))).toEqual(testData);
   });
 
+  it('reads and writes Object with key length', () => {
+    // See: https://github.com/lodash/lodash/issues/5870
+    const testData = {
+      a: 1,
+      b: 2,
+      c: [3, 4, 5],
+      d: {
+        e: true,
+      },
+      length: 10,
+    };
+
+    const r = reader();
+    const w = writer();
+
+    expect(r.read(w.write(testData))).toEqual(testData);
+  });
+
   it('reads and writes transit JSON verbose', () => {
     const testData = {
       a: 1,

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,6 +1,16 @@
 import _ from 'lodash';
 
 /**
+ Null-safe version of Object.entries
+ */
+export const entries = obj => {
+  if (obj == null) {
+    return [];
+  }
+  return Object.entries(obj);
+};
+
+/**
    Take URL and remove the trailing slashes.
 
    Example:
@@ -17,14 +27,13 @@ export const fnPath = path =>
   _.without(path.split('/'), '').map(part => part.replace(/_\w/g, m => m[1].toUpperCase()));
 
 export const formData = params =>
-  _.reduce(
-    params,
-    (pairs, v, k) => {
+  entries(params)
+    .reduce((pairs, entry) => {
+      const [k, v] = entry;
       pairs.push(`${encodeURIComponent(k)}=${encodeURIComponent(v)}`);
       return pairs;
-    },
-    []
-  ).join('&');
+    }, [])
+    .join('&');
 
 /**
    Serialize a single attribute in an object query parameter.

--- a/src/utils.test.js
+++ b/src/utils.test.js
@@ -1,4 +1,10 @@
-import { fnPath, trimEndSlash, formData, objectQueryString, canonicalAssetPaths } from './utils';
+import {
+  fnPath,
+  trimEndSlash,
+  formData,
+  objectQueryString,
+  canonicalAssetPaths,
+} from './utils';
 
 describe('utils', () => {
   describe('pathToMethodName', () => {
@@ -32,6 +38,11 @@ describe('utils', () => {
       expect(
         formData({ username: 'joe.dunphy@example.com', password: '}4$3.872487=3&&]/6?.' })
       ).toEqual('username=joe.dunphy%40example.com&password=%7D4%243.872487%3D3%26%26%5D%2F6%3F.');
+    });
+
+    it('encodes Object with key length', () => {
+      // See: https://github.com/lodash/lodash/issues/5870
+      expect(formData({ length: 10 })).toEqual('length=10');
     });
   });
 


### PR DESCRIPTION
This commit fixes a bug where SDK fails to serialize JavaScript Objects if they contain key 'length' with number value.

The reason for this bug seems to be in lodash `_.reduce` function. See https://github.com/lodash/lodash/issues/5870

The solution is to use Object.entries + reduce instead of lodash reduce.