### PR TITLE
Drop unnecessary fileId from the example

### DIFF
--- a/docs/file-uploads-and-downloads.md
+++ b/docs/file-uploads-and-downloads.md
@@ -109,9 +109,8 @@ sdk.ownFiles.create({
 
     // Step 2: Request a presigned upload URL for this file
     return sdk.fileUploads.create({ fileId })
-      .then(uploadResponse => ({ fileId, uploadResponse }));
   })
-  .then(({ uploadResponse }) => {
+  .then(uploadResponse => {
     const { method, url, headers } = uploadResponse.data.data.attributes;
 
     // Step 3: Upload the file directly to cloud storage


### PR DESCRIPTION
It seems that bundling the `fileId` with the `uploadResponse` is unnecessary. The `.then` chain does not use it.