### PR TITLE
SDK releases with endpoints not yet available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,19 @@ The format is based on [Keep a
 Changelog](http://keepachangelog.com/en/1.0.0/) and this project
 adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+SDK releases may include support for API endpoints that are not yet publicly
+available at the time of the release. These endpoints are marked with `[API not
+yet available]` tag in the changelog. The tag is removed when the API endpoint
+becomes available. For the most up-to-date information on API availability, see
+the [Sharetribe API
+changelog](https://www.sharetribe.com/api-reference/changelog.html).
+
 ## [Unreleased] - xxxx-xx-xx
+
+### Changed
+
+- Future SDK releases may include support for API endpoints that are not yet
+  publicly available. Changed CHANGELOG.md to reflect this change.
 
 ## [v1.24.1] - 2026-07-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 ### Changed
 - Update dependencies [#215](https://github.com/sharetribe/flex-sdk-js/pull/215)
   - axios: 1.5.1 > 1.18.1
-  - lodash: 4.17.10 > 4.18.1  
+  - lodash: 4.17.10 > 4.18.1
 
 ## [v1.24.0] - 2026-05-25
 

--- a/docs/developing-sdk.md
+++ b/docs/developing-sdk.md
@@ -86,6 +86,8 @@ $ git checkout master
 
    - Move everything in Unreleased to the corresponding version section
    - Update the version links found at the very bottom of the CHANGELOG.md file
+   - Mark any endpoints whose API is not yet publicly available with
+     `[API not yet available]`
 
 1. Commit and push
 
@@ -147,3 +149,13 @@ $ git checkout master
     ```
 
 1.  Announce the new version in Slack
+
+    - If the release includes only new endpoints with `[API not yet available]`, 
+      postpone the annoucements until the API becomes available.
+
+1. When a previously unreleased API endpoint becomes available
+
+    1. Remove the `[API not yet available]` tag from the corresponding
+       entries in CHANGELOG.md
+    1. Commit and push
+    1. Annouce in Slack

--- a/docs/developing-sdk.md
+++ b/docs/developing-sdk.md
@@ -158,4 +158,5 @@ $ git checkout master
     1. Remove the `[API not yet available]` tag from the corresponding
        entries in CHANGELOG.md
     1. Commit and push
+    1. Remove the `[API not yet available]` tag from the corresponding [Github Release notes](https://github.com/sharetribe/flex-sdk-js/releases)
     1. Annouce in Slack


### PR DESCRIPTION
SDK releases may include support for API endpoints that are not yet publicly available at the time of the release.