### PR TITLE
Multitenant refresh expires token and retry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,10 +19,14 @@ changelog](https://www.sharetribe.com/api-reference/changelog.html).
 
 - Future SDK releases may include support for API endpoints that are not yet
   publicly available. Changed CHANGELOG.md to reflect this change.
+- Internal. Added refresh and retry mechanism for expired auth tokens for
+  multitenant SDK, which is only used by the Sharetribe-hosted no-code
+  marketplaces.
 
 ## [v1.24.1] - 2026-07-27
 
 ### Changed
+
 - Update dependencies [#215](https://github.com/sharetribe/flex-sdk-js/pull/215)
   - axios: 1.5.1 > 1.18.1
   - lodash: 4.17.10 > 4.18.1

--- a/src/api_config.js
+++ b/src/api_config.js
@@ -1,0 +1,65 @@
+import { formData } from './utils';
+import paramsSerializer from './params_serializer';
+
+const createHeaders = transitVerbose => {
+  if (transitVerbose) {
+    return {
+      'X-Transit-Verbose': 'true',
+      Accept: 'application/transit+json',
+    };
+  }
+
+  return {
+    Accept: 'application/transit+json',
+  };
+};
+
+export const defaultSdkConfig = {
+  clientId: null,
+  clientSecret: null,
+  baseUrl: 'https://flex-api.sharetribe.com',
+  assetCdnBaseUrl: 'https://cdn.st-api.com',
+  typeHandlers: [],
+  adapter: null,
+  version: 'v1',
+  httpAgent: null,
+  httpsAgent: null,
+  transitVerbose: false,
+  disableDeprecationWarnings: false,
+};
+
+export const apis = {
+  api: ({ baseUrl, version, adapter, httpAgent, httpsAgent, transitVerbose }) => ({
+    headers: createHeaders(transitVerbose),
+    baseURL: `${baseUrl}/${version}`,
+    transformRequest: v => v,
+    transformResponse: v => v,
+    adapter,
+    paramsSerializer,
+    httpAgent,
+    httpsAgent,
+  }),
+  auth: ({ baseUrl, version, adapter, httpAgent, httpsAgent }) => ({
+    headers: {
+      'Content-Type': 'application/x-www-form-urlencoded',
+      Accept: 'application/json',
+    },
+    baseURL: `${baseUrl}/${version}/`,
+    transformRequest: [data => formData(data)],
+    // using default transformRequest, which can handle JSON and fallback to plain
+    // test if JSON parsing fails
+    adapter,
+    httpAgent,
+    httpsAgent,
+  }),
+  assets: ({ assetCdnBaseUrl, version, adapter, httpAgent, httpsAgent }) => ({
+    headers: {
+      Accept: 'application/json',
+    },
+    baseURL: `${assetCdnBaseUrl}/${version}`,
+    adapter,
+    paramsSerializer,
+    httpAgent,
+    httpsAgent,
+  }),
+};

--- a/src/auth_token_context_runner.js
+++ b/src/auth_token_context_runner.js
@@ -1,0 +1,41 @@
+import contextRunner from './context_runner';
+import SaveToken from './interceptors/save_token';
+import AddAuthTokenResponse from './interceptors/add_auth_token_response';
+
+// Set and get the interceptor that calls /auth/token endpoint to the ctx
+export const setAuthTokenInterceptors = (ctx, authTokenInterceptors) => ({
+  ...ctx,
+  authTokenInterceptors,
+});
+export const getAuthTokenInterceptors = ctx => ctx.authTokenInterceptors;
+
+/**
+   Create a new context running for interceptors that will call /auth/token
+   endpoint and save the new token to the token store.
+ */
+const createContextRunner = ctx =>
+  contextRunner([new SaveToken(), new AddAuthTokenResponse(), ...getAuthTokenInterceptors(ctx)]);
+
+/**
+   Request a new token
+ 
+   Options:
+   - `ctx`
+   - `params` to pass to `/auth/token` endpoint
+
+   Returns a Promise
+
+   The function creates a new context runner and immediately runs it with the given params.
+
+   The interceptors that call the `/auth/token` endpoint must be set with
+   `setAuthTokenInterceptors` before calling this function. This is usually done
+   during the initialization of the SDK instance.
+ 
+   This function is used by interceptors that need to request a new token, i.e.
+   interceptors that retry with refresh/anon token and fetch new anon token
+
+   Token request uses token store from ctx, which allows the new token to be
+   saved to the store.
+ */
+export const requestToken = (ctx, params) =>
+  createContextRunner(ctx)({ params, tokenStore: ctx.tokenStore });

--- a/src/fake/adapter.js
+++ b/src/fake/adapter.js
@@ -130,13 +130,18 @@ const defaultHandler = (config, resolve, reject, tokenStore) => {
 };
 
 /**
-   Create a fake adapter instance.
+   Create a fake adapter instance which is passed to axios.
+
+   Adapters allow you to customize the way axios handles the request data. The
+   fake adapter does NOT do a real HTTP call, instead, we fake it here and
+   implement a "fake" backend.
 
    Features:
 
    - Handle requests
    - Store all requests (so that they can be inspected in tests)
-   - Implement fake token store
+   - Implement fake token store. Should not be confused the SDK's token store.
+     This on is the backend side storage for known access tokens.
 */
 const createAdapter = handlerFn => {
   const requests = [];

--- a/src/fake/auth.js
+++ b/src/fake/auth.js
@@ -90,12 +90,16 @@ export const multitenantAuthData = (config, resolve, reject, fakeTokenStore) => 
         },
       };
     } else if (formData.grant_type === 'multitenant_token_exchange') {
-      success = {
-        ...fakeTokenStore.exchangeToken(formData.subject_token),
-        client_data: {
-          client_id: '08ec69f6-d37e-414d-83eb-324e94afddf0',
-        },
-      };
+      const exchangedToken = fakeTokenStore.exchangeToken(formData.subject_token);
+
+      if (exchangedToken) {
+        success = {
+          ...exchangedToken,
+          client_data: {
+            client_id: '08ec69f6-d37e-414d-83eb-324e94afddf0',
+          },
+        };
+      }
     }
   } else if (hostname === 'invalid.example.com') {
     error = {

--- a/src/fake/token_store.js
+++ b/src/fake/token_store.js
@@ -6,7 +6,13 @@ const createTokenStore = () => {
   let accessTokenCount = 0;
   let refreshTokenCount = 0;
 
-  const knownUsers = [['joe.dunphy@example.com', 'secret-joe']];
+  const knownUsers = {
+    'joe.dunphy@example.com': {
+      username: 'joe.dunphy@example.com',
+      password: 'secret-joe',
+      clientId: '08ec69f6-d37e-414d-83eb-324e94afddf0',
+    },
+  };
 
   const knownAuthorizationCodes = [
     { code: 'flex-authorization-code', username: 'joe.dunphy@example.com' },
@@ -67,9 +73,13 @@ const createTokenStore = () => {
   };
 
   const createTokenWithCredentials = (username, password) => {
-    const user = _.find(knownUsers, u => _.isEqual(u, [username, password]));
+    const user = knownUsers[username];
 
     if (!user) {
+      return null;
+    }
+
+    if (user.password !== password) {
       return null;
     }
 
@@ -77,6 +87,7 @@ const createTokenStore = () => {
       token: {
         access_token: generateAccessToken(username),
         refresh_token: generateRefreshToken(username),
+        client_id: user.clientId,
         token_type: 'bearer',
         expires_in: 86400,
         scope: 'user',

--- a/src/fake/token_store.js
+++ b/src/fake/token_store.js
@@ -87,7 +87,7 @@ const createTokenStore = () => {
     };
     tokens.push(token);
 
-    return token.token;
+    return { ...token.token };
   };
 
   const createTokenWithAuthorizationCode = authorizationCode => {

--- a/src/fake/token_store.js
+++ b/src/fake/token_store.js
@@ -213,7 +213,7 @@ const createTokenStore = () => {
           refresh_token: generateRefreshToken(username),
           token_type: 'bearer',
           expires_in: 86400,
-          // TODO missing `scope`
+          scope: 'user',
         },
         user: {
           username,

--- a/src/interceptors/add_multitenant_token_exchange_params.js
+++ b/src/interceptors/add_multitenant_token_exchange_params.js
@@ -15,29 +15,27 @@ import _ from 'lodash';
 */
 export default class AddMultitenantTokenExchangeParams {
   enter(ctx) {
-    const { tokenStore } = ctx;
-    return Promise.resolve()
-      .then(tokenStore.getToken)
-      .then(storedToken => {
-        // throw if no token is found
-        if (!storedToken || !storedToken.access_token) {
-          throw new Error('No access token found in store');
-        }
-        // throw if token has invalid scope
-        const scopes = storedToken.scope.split(' ');
-        if (!_.find(scopes, scope => scope === 'user')) {
-          throw new Error('Access token scope not supported');
-        }
+    const { authToken } = ctx;
+    return Promise.resolve().then(() => {
+      // throw if no token is found
+      if (!authToken || !authToken.access_token) {
+        throw new Error('No access token found in store');
+      }
+      // throw if token has invalid scope
+      const scopes = authToken.scope.split(' ');
+      if (!_.find(scopes, scope => scope === 'user')) {
+        throw new Error('Access token scope not supported');
+      }
 
-        return {
-          ...ctx,
-          params: {
-            ...ctx.params,
-            scope: 'trusted:user',
-            grant_type: 'multitenant_token_exchange',
-            subject_token: storedToken.access_token,
-          },
-        };
-      });
+      return {
+        ...ctx,
+        params: {
+          ...ctx.params,
+          scope: 'trusted:user',
+          grant_type: 'multitenant_token_exchange',
+          subject_token: authToken.access_token,
+        },
+      };
+    });
   }
 }

--- a/src/interceptors/fetch_auth_token_from_api.js
+++ b/src/interceptors/fetch_auth_token_from_api.js
@@ -1,6 +1,4 @@
-import contextRunner from '../context_runner';
-import SaveToken from './save_token';
-import AddAuthTokenResponse from './add_auth_token_response';
+import * as authTokenContextRunner from '../auth_token_context_runner';
 
 /**
    Create a store for in-flight auth request. 
@@ -19,24 +17,17 @@ export function createInFlightAuthRequestStore() {
 */
 export default class FetchAuthTokenFromApi {
   enter(ctx) {
-    const { tokenStore, authToken, endpointInterceptors, clientId, inFlightAuthRequestStore } = ctx;
+    const { authToken, clientId, inFlightAuthRequestStore } = ctx;
 
     if (authToken) {
       return ctx;
     }
 
     if (!inFlightAuthRequestStore.inFlightRequest) {
-      inFlightAuthRequestStore.inFlightRequest = contextRunner([
-        new SaveToken(),
-        new AddAuthTokenResponse(),
-        ...endpointInterceptors.auth.token,
-      ])({
-        params: {
-          client_id: clientId,
-          grant_type: 'client_credentials',
-          scope: 'public-read',
-        },
-        tokenStore,
+      inFlightAuthRequestStore.inFlightRequest = authTokenContextRunner.requestToken(ctx, {
+        client_id: clientId,
+        grant_type: 'client_credentials',
+        scope: 'public-read',
       });
     }
 

--- a/src/interceptors/retry_with_anon_token.js
+++ b/src/interceptors/retry_with_anon_token.js
@@ -1,6 +1,4 @@
-import contextRunner from '../context_runner';
-import SaveToken from './save_token';
-import AddAuthTokenResponse from './add_auth_token_response';
+import * as authTokenContextRunner from '../auth_token_context_runner';
 
 /**
    Retries with a fresh anon token.
@@ -29,8 +27,6 @@ export default class RetryWithAnonToken {
   error(errorCtx) {
     const {
       clientId,
-      tokenStore,
-      endpointInterceptors,
       anonTokenRetry: { retryQueue, attempts },
     } = errorCtx;
 
@@ -39,18 +35,13 @@ export default class RetryWithAnonToken {
     }
 
     if (errorCtx.res && errorCtx.res.status === 401) {
-      return contextRunner([
-        new SaveToken(),
-        new AddAuthTokenResponse(),
-        ...endpointInterceptors.auth.token,
-      ])({
-        params: {
+      return authTokenContextRunner
+        .requestToken(errorCtx, {
           client_id: clientId,
           grant_type: 'client_credentials',
           scope: 'public-read',
-        },
-        tokenStore,
-      }).then(({ authToken }) => ({ ...errorCtx, authToken, enterQueue: retryQueue, error: null }));
+        })
+        .then(({ authToken }) => ({ ...errorCtx, authToken, enterQueue: retryQueue, error: null }));
     }
 
     return errorCtx;

--- a/src/interceptors/retry_with_refresh_token.js
+++ b/src/interceptors/retry_with_refresh_token.js
@@ -38,6 +38,9 @@ export default class RetryWithRefreshToken {
     if (errorCtx.res && errorCtx.res.status === 401 && authToken.refresh_token) {
       return authTokenContextRunner
         .requestToken(errorCtx, {
+          // Use client_id from authToken instead of using client_id from ctx so
+          // that this work for multitenant too (where we don't have client_id
+          // configured.)
           client_id: authToken.client_id,
           grant_type: 'refresh_token',
           refresh_token: authToken.refresh_token,

--- a/src/interceptors/retry_with_refresh_token.js
+++ b/src/interceptors/retry_with_refresh_token.js
@@ -1,6 +1,4 @@
-import contextRunner from '../context_runner';
-import SaveToken from './save_token';
-import AddAuthTokenResponse from './add_auth_token_response';
+import * as authTokenContextRunner from '../auth_token_context_runner';
 
 /**
    Retries with a fresh password token.
@@ -30,8 +28,6 @@ export default class RetryWithRefreshToken {
   error(errorCtx) {
     const {
       authToken,
-      tokenStore,
-      endpointInterceptors,
       refreshTokenRetry: { retryQueue, attempts },
     } = errorCtx;
 
@@ -40,18 +36,12 @@ export default class RetryWithRefreshToken {
     }
 
     if (errorCtx.res && errorCtx.res.status === 401 && authToken.refresh_token) {
-      return contextRunner([
-        new SaveToken(),
-        new AddAuthTokenResponse(),
-        ...endpointInterceptors.auth.token,
-      ])({
-        params: {
+      return authTokenContextRunner
+        .requestToken(errorCtx, {
           client_id: authToken.client_id,
           grant_type: 'refresh_token',
           refresh_token: authToken.refresh_token,
-        },
-        tokenStore,
-      })
+        })
         .then(({ authToken: newAuthToken }) => ({
           ...errorCtx,
           authToken: newAuthToken,

--- a/src/interceptors/retry_with_refresh_token.js
+++ b/src/interceptors/retry_with_refresh_token.js
@@ -30,7 +30,6 @@ export default class RetryWithRefreshToken {
   error(errorCtx) {
     const {
       authToken,
-      clientId,
       tokenStore,
       endpointInterceptors,
       refreshTokenRetry: { retryQueue, attempts },
@@ -47,7 +46,7 @@ export default class RetryWithRefreshToken {
         ...endpointInterceptors.auth.token,
       ])({
         params: {
-          client_id: clientId,
+          client_id: authToken.client_id,
           grant_type: 'refresh_token',
           refresh_token: authToken.refresh_token,
         },

--- a/src/multitenant_sdk.js
+++ b/src/multitenant_sdk.js
@@ -191,11 +191,6 @@ const validateSdkConfig = sdkConfig => {
 };
 
 const createAuthApiEndpointInterceptors = httpOpts =>
-  // Create `endpointInterceptors` object, which is object
-  // containing interceptors for all defined endpoints.
-  // This object can be passed to other interceptors in the interceptor context so they
-  // are able to do API calls (e.g. authentication interceptors)
-  //
   multitenantAuthApi.reduce((acc, { path, method }) => {
     const fnPath = urlPathToFnPath(path);
     const url = `auth/multitenant/${path}`;
@@ -218,12 +213,7 @@ export default class MultitenantSharetribeSdk {
     const apiConfigs = _.mapValues(apis, apiConfig => apiConfig(sdkConfig));
     const authApiEndpointInterceptors = createAuthApiEndpointInterceptors(apiConfigs.auth);
 
-    const allEndpointInterceptors = {
-      auth: authApiEndpointInterceptors,
-    };
-
     const ctx = {
-      endpointInterceptors: allEndpointInterceptors,
       multitenantClientSecret: sdkConfig.multitenantClientSecret,
       hostname: sdkConfig.hostname,
       tokenStore: sdkConfig.tokenStore,

--- a/src/multitenant_sdk.js
+++ b/src/multitenant_sdk.js
@@ -190,7 +190,7 @@ const validateSdkConfig = sdkConfig => {
   return sdkConfig;
 };
 
-const createAuthApiEndpointInterceptors = httpOpts =>
+const createMultitenantAuthApiEndpointInterceptors = httpOpts =>
   multitenantAuthApi.reduce((acc, { path, method }) => {
     const fnPath = urlPathToFnPath(path);
     const url = `auth/multitenant/${path}`;
@@ -211,7 +211,9 @@ export default class MultitenantSharetribeSdk {
 
     // Instantiate API configs
     const apiConfigs = _.mapValues(apis, apiConfig => apiConfig(sdkConfig));
-    const authApiEndpointInterceptors = createAuthApiEndpointInterceptors(apiConfigs.auth);
+    const multitenantAuthApiEndpointInterceptors = createMultitenantAuthApiEndpointInterceptors(
+      apiConfigs.auth
+    );
 
     const ctx = {
       multitenantClientSecret: sdkConfig.multitenantClientSecret,
@@ -220,7 +222,7 @@ export default class MultitenantSharetribeSdk {
     };
 
     // Assign SDK functions to 'this'
-    authApiSdkFns(authApiEndpointInterceptors, ctx).forEach(({ path, fn }) =>
+    authApiSdkFns(multitenantAuthApiEndpointInterceptors, ctx).forEach(({ path, fn }) =>
       _.set(this, path, fn)
     );
   }

--- a/src/multitenant_sdk.js
+++ b/src/multitenant_sdk.js
@@ -1,7 +1,9 @@
 import _ from 'lodash';
 import { fnPath as urlPathToFnPath, trimEndSlash, formData } from './utils';
+import { authApi as authApiEndpoints } from './endpoints';
 import AddMultitenantAuthTokenResponse from './interceptors/add_multitenant_auth_token_response';
 import SaveToken from './interceptors/save_token';
+import RetryWithRefreshToken from './interceptors/retry_with_refresh_token';
 import FetchAuthTokenFromStore from './interceptors/fetch_auth_token_from_store';
 import AddMultitenantClientSecretTokenToCtx from './interceptors/add_multitenant_client_secret_token_to_ctx';
 import AddMultitenantClientSecretToParams from './interceptors/add_multitenant_client_secret_to_params';
@@ -16,6 +18,7 @@ import createSdkFnContextRunner from './sdk_context_runner';
 import memoryStore from './memory_store';
 import contextRunner from './context_runner';
 import { isBrowser } from './runtime';
+import * as authTokenContextRunner from './auth_token_context_runner';
 
 /* eslint-disable class-methods-use-this */
 
@@ -72,6 +75,7 @@ const tokenExchangeInterceptors = authApiEndpointInterceptors => [
   new FormatHttpResponse(),
   new FormatMultitenantHttpResponse(),
   new FetchAuthTokenFromStore(),
+  new RetryWithRefreshToken(),
   new AddMultitenantClientSecretTokenToCtx(),
   new AddMultitenantClientSecretToParams(),
   new AddMultitenantTokenExchangeParams(),
@@ -190,6 +194,13 @@ const validateSdkConfig = sdkConfig => {
   return sdkConfig;
 };
 
+const createAuthApiEndpointInterceptors = httpOpts =>
+  authApiEndpoints.reduce((acc, { path, method }) => {
+    const fnPath = urlPathToFnPath(path);
+    const url = `auth/${path}`;
+    return _.set(acc, fnPath, [endpointRequest({ method, url, httpOpts })]);
+  }, {});
+
 const createMultitenantAuthApiEndpointInterceptors = httpOpts =>
   multitenantAuthApi.reduce((acc, { path, method }) => {
     const fnPath = urlPathToFnPath(path);
@@ -211,15 +222,18 @@ export default class MultitenantSharetribeSdk {
 
     // Instantiate API configs
     const apiConfigs = _.mapValues(apis, apiConfig => apiConfig(sdkConfig));
+    const authApiEndpointInterceptors = createAuthApiEndpointInterceptors(apiConfigs.auth);
     const multitenantAuthApiEndpointInterceptors = createMultitenantAuthApiEndpointInterceptors(
       apiConfigs.auth
     );
 
-    const ctx = {
+    let ctx = {
       multitenantClientSecret: sdkConfig.multitenantClientSecret,
       hostname: sdkConfig.hostname,
       tokenStore: sdkConfig.tokenStore,
     };
+
+    ctx = authTokenContextRunner.setAuthTokenInterceptors(ctx, authApiEndpointInterceptors.token);
 
     // Assign SDK functions to 'this'
     authApiSdkFns(multitenantAuthApiEndpointInterceptors, ctx).forEach(({ path, fn }) =>

--- a/src/multitenant_sdk.js
+++ b/src/multitenant_sdk.js
@@ -1,5 +1,5 @@
 import _ from 'lodash';
-import { fnPath as urlPathToFnPath, trimEndSlash, formData } from './utils';
+import { fnPath as urlPathToFnPath, trimEndSlash } from './utils';
 import { authApi as authApiEndpoints } from './endpoints';
 import AddMultitenantAuthTokenResponse from './interceptors/add_multitenant_auth_token_response';
 import SaveToken from './interceptors/save_token';
@@ -19,17 +19,13 @@ import memoryStore from './memory_store';
 import contextRunner from './context_runner';
 import { isBrowser } from './runtime';
 import * as authTokenContextRunner from './auth_token_context_runner';
+import { apis, defaultSdkConfig } from './api_config';
 
 /* eslint-disable class-methods-use-this */
 
-const defaultSdkConfig = {
+const multitenantSdkConfig = {
   hostname: null,
   multitenantClientSecret: null,
-  baseUrl: 'https://flex-api.sharetribe.com',
-  adapter: null,
-  version: 'v1',
-  httpAgent: null,
-  httpsAgent: null,
 };
 
 const multitenantAuthApi = [
@@ -46,20 +42,6 @@ const multitenantAuthApi = [
     method: 'post',
   },
 ];
-
-const apis = {
-  auth: ({ baseUrl, version, adapter, httpAgent, httpsAgent }) => ({
-    headers: {
-      'Content-Type': 'application/x-www-form-urlencoded',
-      Accept: 'application/json',
-    },
-    baseURL: `${baseUrl}/${version}/`,
-    transformRequest: [data => formData(data)],
-    adapter,
-    httpAgent,
-    httpsAgent,
-  }),
-};
 
 const tokenInterceptors = authApiEndpointInterceptors => [
   new FormatHttpResponse(),
@@ -217,7 +199,7 @@ export default class MultitenantSharetribeSdk {
   constructor(userSdkConfig) {
     // Transform and validation SDK configurations
     const sdkConfig = validateSdkConfig(
-      transformSdkConfig({ ...defaultSdkConfig, ...userSdkConfig })
+      transformSdkConfig({ ...defaultSdkConfig, ...multitenantSdkConfig, ...userSdkConfig })
     );
 
     // Instantiate API configs

--- a/src/multitenant_sdk.js
+++ b/src/multitenant_sdk.js
@@ -2,6 +2,7 @@ import _ from 'lodash';
 import { fnPath as urlPathToFnPath, trimEndSlash, formData } from './utils';
 import AddMultitenantAuthTokenResponse from './interceptors/add_multitenant_auth_token_response';
 import SaveToken from './interceptors/save_token';
+import FetchAuthTokenFromStore from './interceptors/fetch_auth_token_from_store';
 import AddMultitenantClientSecretTokenToCtx from './interceptors/add_multitenant_client_secret_token_to_ctx';
 import AddMultitenantClientSecretToParams from './interceptors/add_multitenant_client_secret_to_params';
 import AddMultitenantTokenExchangeParams from './interceptors/add_multitenant_token_exchange_params';
@@ -62,6 +63,18 @@ const tokenInterceptors = authApiEndpointInterceptors => [
   new FormatMultitenantHttpResponse(),
   new AddMultitenantClientSecretTokenToCtx(),
   new AddMultitenantClientSecretToParams(),
+  new SaveToken(),
+  new AddMultitenantAuthTokenResponse(),
+  ..._.get(authApiEndpointInterceptors, 'token'),
+];
+
+const tokenExchangeInterceptors = authApiEndpointInterceptors => [
+  new FormatHttpResponse(),
+  new FormatMultitenantHttpResponse(),
+  new FetchAuthTokenFromStore(),
+  new AddMultitenantClientSecretTokenToCtx(),
+  new AddMultitenantClientSecretToParams(),
+  new AddMultitenantTokenExchangeParams(),
   new SaveToken(),
   new AddMultitenantAuthTokenResponse(),
   ..._.get(authApiEndpointInterceptors, 'token'),
@@ -137,10 +150,7 @@ const authApiSdkFns = (authApiEndpointInterceptors, ctx) => [
     path: 'tokenExchange',
     fn: createAuthApiSdkFn({
       ctx,
-      interceptors: [
-        new AddMultitenantTokenExchangeParams(),
-        ...tokenInterceptors(authApiEndpointInterceptors),
-      ],
+      interceptors: tokenExchangeInterceptors(authApiEndpointInterceptors),
     }),
   },
   {

--- a/src/multitenant_sdk.test.js
+++ b/src/multitenant_sdk.test.js
@@ -285,6 +285,27 @@ describe('new MultitenantSharetribeSdk', () => {
         })
       );
     });
+
+    it('expired access token returns 401 because multitenant token exchange does not implement expired token refresh and retry', () => {
+      const { sdk, sdkTokenStore, adapterTokenStore } = createSdk();
+      const userToken = adapterTokenStore.createTokenWithCredentials(
+        'joe.dunphy@example.com',
+        'secret-joe'
+      );
+      sdkTokenStore.setToken({ ...userToken });
+      adapterTokenStore.expireAccessToken(userToken.access_token);
+
+      return report(
+        sdk.tokenExchange().catch(e => {
+          expect(e).toBeInstanceOf(Error);
+          expect(e).toEqual(
+            expect.objectContaining({
+              status: 401,
+            })
+          );
+        })
+      );
+    });
   });
 
   describe('loginWithIdp', () => {

--- a/src/multitenant_sdk.test.js
+++ b/src/multitenant_sdk.test.js
@@ -286,7 +286,7 @@ describe('new MultitenantSharetribeSdk', () => {
       );
     });
 
-    it('expired access token returns 401 because multitenant token exchange does not implement expired token refresh and retry', () => {
+    it('tokenExchange refreshes expired token', () => {
       const { sdk, sdkTokenStore, adapterTokenStore } = createSdk();
       const userToken = adapterTokenStore.createTokenWithCredentials(
         'joe.dunphy@example.com',
@@ -295,14 +295,21 @@ describe('new MultitenantSharetribeSdk', () => {
       sdkTokenStore.setToken({ ...userToken });
       adapterTokenStore.expireAccessToken(userToken.access_token);
 
+      expect(sdkTokenStore.getToken().access_token).toEqual('joe.dunphy@example.com-access-1');
+
       return report(
-        sdk.tokenExchange().catch(e => {
-          expect(e).toBeInstanceOf(Error);
-          expect(e).toEqual(
-            expect.objectContaining({
-              status: 401,
-            })
-          );
+        sdk.tokenExchange().then(res => {
+          // There are three tokens generated:
+          // 1: The initial token
+          // 2: The refreshed token
+          // 3: The exchanged token
+          expect(sdkTokenStore.getToken().access_token).toEqual('joe.dunphy@example.com-access-3');
+
+          expect(res.data).toEqual({
+            client_data: {
+              client_id: '08ec69f6-d37e-414d-83eb-324e94afddf0',
+            },
+          });
         })
       );
     });

--- a/src/sdk.js
+++ b/src/sdk.js
@@ -1,11 +1,10 @@
 import _ from 'lodash';
-import { fnPath as urlPathToFnPath, trimEndSlash, formData, canonicalAssetPaths } from './utils';
+import { fnPath as urlPathToFnPath, trimEndSlash, canonicalAssetPaths } from './utils';
 import {
   marketplaceApi as marketplaceApiEndpoints,
   authApi as authApiEndpoints,
   assetsApi as assetsApiEndpoints,
 } from './endpoints';
-import paramsSerializer from './params_serializer';
 import AddAuthHeader from './interceptors/add_auth_header';
 import RetryWithRefreshToken from './interceptors/retry_with_refresh_token';
 import RetryWithAnonToken from './interceptors/retry_with_anon_token';
@@ -37,22 +36,9 @@ import { createDefaultTokenStore } from './token_store';
 import createSdkFnContextRunner from './sdk_context_runner';
 import { isBrowser } from './runtime';
 import * as authTokenContextRunner from './auth_token_context_runner';
+import { apis, defaultSdkConfig } from './api_config';
 
 /* eslint-disable class-methods-use-this */
-
-const defaultSdkConfig = {
-  clientId: null,
-  clientSecret: null,
-  baseUrl: 'https://flex-api.sharetribe.com',
-  assetCdnBaseUrl: 'https://cdn.st-api.com',
-  typeHandlers: [],
-  adapter: null,
-  version: 'v1',
-  httpAgent: null,
-  httpsAgent: null,
-  transitVerbose: false,
-  disableDeprecationWarnings: false,
-};
 
 /**
    Basic configurations for different 'apis'.
@@ -68,55 +54,6 @@ const defaultSdkConfig = {
    what are the headers that should be always sent and
    how to transform requests and response, etc.
  */
-
-const createHeaders = transitVerbose => {
-  if (transitVerbose) {
-    return {
-      'X-Transit-Verbose': 'true',
-      Accept: 'application/transit+json',
-    };
-  }
-
-  return {
-    Accept: 'application/transit+json',
-  };
-};
-
-const apis = {
-  api: ({ baseUrl, version, adapter, httpAgent, httpsAgent, transitVerbose }) => ({
-    headers: createHeaders(transitVerbose),
-    baseURL: `${baseUrl}/${version}`,
-    transformRequest: v => v,
-    transformResponse: v => v,
-    adapter,
-    paramsSerializer,
-    httpAgent,
-    httpsAgent,
-  }),
-  auth: ({ baseUrl, version, adapter, httpAgent, httpsAgent }) => ({
-    headers: {
-      'Content-Type': 'application/x-www-form-urlencoded',
-      Accept: 'application/json',
-    },
-    baseURL: `${baseUrl}/${version}/`,
-    transformRequest: [data => formData(data)],
-    // using default transformRequest, which can handle JSON and fallback to plain
-    // test if JSON parsing fails
-    adapter,
-    httpAgent,
-    httpsAgent,
-  }),
-  assets: ({ assetCdnBaseUrl, version, adapter, httpAgent, httpsAgent }) => ({
-    headers: {
-      Accept: 'application/json',
-    },
-    baseURL: `${assetCdnBaseUrl}/${version}`,
-    adapter,
-    paramsSerializer,
-    httpAgent,
-    httpsAgent,
-  }),
-};
 
 const authenticateInterceptors = [
   new FetchAuthTokenFromStore(),

--- a/src/sdk.js
+++ b/src/sdk.js
@@ -36,6 +36,7 @@ import endpointRequest from './interceptors/endpoint_request';
 import { createDefaultTokenStore } from './token_store';
 import createSdkFnContextRunner from './sdk_context_runner';
 import { isBrowser } from './runtime';
+import * as authTokenContextRunner from './auth_token_context_runner';
 
 /* eslint-disable class-methods-use-this */
 
@@ -448,11 +449,6 @@ const validateSdkConfig = sdkConfig => {
 };
 
 const createMarketplaceApiEndpointInterceptors = httpOpts =>
-  // Create `endpointInterceptors` object, which is object
-  // containing interceptors for all defined endpoints.
-  // This object can be passed to other interceptors in the interceptor context so they
-  // are able to do API calls (e.g. authentication interceptors)
-  //
   marketplaceApiEndpoints.reduce((acc, { path, method, multipart }) => {
     const fnPath = urlPathToFnPath(path);
     const url = `api/${path}`;
@@ -474,11 +470,6 @@ const createMarketplaceApiEndpointInterceptors = httpOpts =>
   }, {});
 
 const createAuthApiEndpointInterceptors = httpOpts =>
-  // Create `endpointInterceptors` object, which is object
-  // containing interceptors for all defined endpoints.
-  // This object can be passed to other interceptors in the interceptor context so they
-  // are able to do API calls (e.g. authentication interceptors)
-  //
   authApiEndpoints.reduce((acc, { path, method }) => {
     const fnPath = urlPathToFnPath(path);
     const url = `auth/${path}`;
@@ -486,11 +477,6 @@ const createAuthApiEndpointInterceptors = httpOpts =>
   }, {});
 
 const createAssetsApiEndpointInterceptors = httpOpts =>
-  // Create `endpointInterceptors` object, which is object
-  // containing interceptors for all defined endpoints.
-  // This object can be passed to other interceptors in the interceptor context so they
-  // are able to do API calls (e.g. authentication interceptors)
-  //
   assetsApiEndpoints.reduce((acc, { pathFn, method, name }) => {
     const urlTemplate = pathParams => `assets/${pathFn(pathParams)}`;
     return _.set(acc, name, [endpointRequest({ method, urlTemplate, httpOpts })]);
@@ -517,15 +503,8 @@ export default class SharetribeSdk {
     const authApiEndpointInterceptors = createAuthApiEndpointInterceptors(apiConfigs.auth);
     const assetsApiEndpointInterceptors = createAssetsApiEndpointInterceptors(apiConfigs.assets);
 
-    const allEndpointInterceptors = {
-      api: marketplaceApiEndpointInterceptors,
-      auth: authApiEndpointInterceptors,
-      assets: assetsApiEndpointInterceptors,
-    };
-
-    const ctx = {
+    let ctx = {
       tokenStore: sdkConfig.tokenStore,
-      endpointInterceptors: allEndpointInterceptors,
       clientId: sdkConfig.clientId,
       clientSecret: sdkConfig.clientSecret,
       typeHandlers: sdkConfig.typeHandlers,
@@ -533,6 +512,8 @@ export default class SharetribeSdk {
       disableDeprecationWarnings: sdkConfig.disableDeprecationWarnings,
       inFlightAuthRequestStore: createInFlightAuthRequestStore(),
     };
+
+    ctx = authTokenContextRunner.setAuthTokenInterceptors(ctx, authApiEndpointInterceptors.token);
 
     // Assign SDK functions to 'this'
     marketplaceApiSdkFns(marketplaceApiEndpointInterceptors, ctx).forEach(({ path, fn }) =>


### PR DESCRIPTION
This PR adds expired token refresh and retry mechanism to multitenant SDK token exchange endpoint.

Multitenant SDK has two other endpoints (client data and auth with idp) but they don't use access token, thus no need to add retry interceptor to those endpoints.

In addition, this PR includes a bit of refactoring and code reorganization.

Review tips:

- Commit by commit
- Hide whitespace
- The beef of this PR is in commit `Retry multitenant token exchange`. Commits before that are refactoring commits, preparing for the actual retry implementation.