### PR TITLE
Update js-cookie

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,10 +19,16 @@ changelog](https://www.sharetribe.com/api-reference/changelog.html).
 
 - Future SDK releases may include support for API endpoints that are not yet
   publicly available. Changed CHANGELOG.md to reflect this change.
+  
+### Security
+
+- Update js-cookie from v2 to v3. This includes a security fix for cookie
+  attribute injection (CVE-2026-46625).[#219](https://github.com/sharetribe/flex-sdk-js/pull/219)
 
 ## [v1.24.1] - 2026-07-27
 
 ### Changed
+
 - Update dependencies [#215](https://github.com/sharetribe/flex-sdk-js/pull/215)
   - axios: 1.5.1 > 1.18.1
   - lodash: 4.17.10 > 4.18.1

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
   },
   "dependencies": {
     "axios": "^1.18.1",
-    "js-cookie": "^2.1.3",
+    "js-cookie": "^3.0.8",
     "jsonwebtoken": "^9.0.3",
     "lodash": "^4.18.1",
     "transit-js": "^0.8.861"

--- a/src/browser_cookie_store.js
+++ b/src/browser_cookie_store.js
@@ -7,10 +7,13 @@ const createStore = ({ clientId, cookieId, secure }) => {
   const namespace = 'st';
   const key = generateKey(clientId || cookieId, namespace);
 
-  const getToken = () => Cookies.getJSON(key);
+  const getToken = () => {
+    const value = Cookies.get(key);
+    return value ? JSON.parse(value) : undefined;
+  };
   const setToken = tokenData => {
     const secureFlag = secure ? { secure: true } : {};
-    Cookies.set(key, tokenData, { expires: expiration, ...secureFlag });
+    Cookies.set(key, JSON.stringify(tokenData), { expires: expiration, ...secureFlag });
   };
   const removeToken = () => {
     Cookies.remove(key);

--- a/yarn.lock
+++ b/yarn.lock
@@ -5914,10 +5914,10 @@ js-base64@^2.1.9:
   resolved "https://registry.yarnpkg.com/js-base64/-/js-base64-2.5.1.tgz#1efa39ef2c5f7980bb1784ade4a8af2de3291121"
   integrity sha512-M7kLczedRMYX4L8Mdh4MzyAMM9O5osx+4FcOQuTvr3A9F2D9S5JXheN0ewNbrvK2UatkTRhL5ejGmGSjNMiZuw==
 
-js-cookie@^2.1.3:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/js-cookie/-/js-cookie-2.2.1.tgz#69e106dc5d5806894562902aa5baec3744e9b2b8"
-  integrity sha512-HvdH2LzI/EAZcUwA8+0nKNtWHqS+ZmijLA30RwZA0bo7ToCckjK5MkGhjED9KoRcXO6BaGI3I9UIzSA1FKFPOQ==
+js-cookie@^3.0.8:
+  version "3.0.8"
+  resolved "https://registry.yarnpkg.com/js-cookie/-/js-cookie-3.0.8.tgz#444e6f4b27a5d844594fef61c9d6bca5f0787688"
+  integrity sha512-yeJd4aNAdYZQjaon2bpD/Gb0B/omw7HQOsynXXcOiWVCacbBcPlgn8S/d1X6blFSaHao7ozqtW7NZW19xpCtIw==
 
 js-levenshtein@^1.1.3:
   version "1.1.6"


### PR DESCRIPTION
Update js-cookie from v2 to v3. This includes a security fix for cookie attribute injection (CVE-2026-46625)