### PR TITLE
Update handlebars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ changelog](https://www.sharetribe.com/api-reference/changelog.html).
 - Update minimist from 1.2.5 to 1.2.8. Fixes (CVE-2021-44906). minimist is a development-time transitive dependency. [#223](https://github.com/sharetribe/flex-sdk-js/pull/223)
 - Update shell-quote from 1.7.1 to 1.8.2. Fixes (CVE-2021-42740). shell-quote is a development-time transitive dependency. [#224](https://github.com/sharetribe/flex-sdk-js/pull/224)
 - Update babel-loader from 8.0.6 to 8.4.1. Fixes prototype pollution in loader-utils (CVE-2022-37601). [#225](https://github.com/sharetribe/flex-sdk-js/pull/225)
+- Update handlebars from 4.7.7 to 4.7.9. Fixes (CVE-2026-33937). handlebars is a development-time transitive dependency. [#226](https://github.com/sharetribe/flex-sdk-js/pull/226)
 
 ## [v1.24.1] - 2026-07-27
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4764,12 +4764,12 @@ gray-matter@^2.0.0:
     toml "^2.3.2"
 
 handlebars@^4.0.1:
-  version "4.7.7"
-  resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.7.7.tgz#9ce33416aad02dbd6c8fafa8240d5d98004945a1"
-  integrity sha512-aAcXm5OAfE/8IXkcZvCepKU3VzW1/39Fb5ZuqMtgI/hT8X2YgoMvBY5dLhq/cpOvw7Lk1nK/UF71aLG/ZnVYRA==
+  version "4.7.9"
+  resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.7.9.tgz#6f139082ab58dc4e5a0e51efe7db5ae890d56a0f"
+  integrity sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==
   dependencies:
     minimist "^1.2.5"
-    neo-async "^2.6.0"
+    neo-async "^2.6.2"
     source-map "^0.6.1"
     wordwrap "^1.0.0"
   optionalDependencies:
@@ -6971,7 +6971,7 @@ negotiator@0.6.2:
   resolved "https://registry.yarnpkg.com/negotiator/-/negotiator-0.6.2.tgz#feacf7ccf525a77ae9634436a64883ffeca346fb"
   integrity sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw==
 
-neo-async@^2.5.0, neo-async@^2.6.0, neo-async@^2.6.1:
+neo-async@^2.5.0, neo-async@^2.6.1, neo-async@^2.6.2:
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/neo-async/-/neo-async-2.6.2.tgz#b4aafb93e3aeb2d8174ca53cf163ab7d7308305f"
   integrity sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==


### PR DESCRIPTION
Handlebars is docpress' transitive dependency. There are some security issues that are fixed in the new version.